### PR TITLE
Drop function abstraction

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,10 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    date (3.4.1)
+    debug (1.10.0)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     diff-lcs (1.5.1)
     docile (1.4.1)
     event_stream_parser (1.0.0)
@@ -26,13 +30,28 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     hashdiff (1.1.2)
+    io-console (0.8.0)
+    irb (1.15.1)
+      pp (>= 0.6.0)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.9.1)
     logger (1.6.5)
     multipart-post (2.4.1)
     net-http (0.6.0)
       uri
+    pp (0.6.2)
+      prettyprint
+    prettyprint (0.2.0)
+    psych (5.2.3)
+      date
+      stringio
     public_suffix (6.0.1)
     rake (13.2.1)
+    rdoc (6.11.0)
+      psych (>= 4.0.0)
+    reline (0.6.0)
+      io-console (~> 0.5)
     rexml (3.4.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -57,6 +76,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    stringio (3.1.2)
     uri (1.0.2)
     vcr (6.3.1)
       base64
@@ -71,6 +91,7 @@ PLATFORMS
 
 DEPENDENCIES
   bristow!
+  debug (~> 1.10)
   rake (~> 13.0)
   rspec (~> 3.0)
   simplecov (~> 0.22)

--- a/README.md
+++ b/README.md
@@ -50,9 +50,19 @@ puts conversation.last['content']
 weather = Bristow::Function.new(
   name: "get_weather",
   description: "Get the current weather for a location",
-  parameters: {
-    location: String,
-    unit: String
+  parameters: { 
+    properties: {
+      location: {
+        type: "string",
+        description: "The city and state, e.g. San Francisco, CA"
+      },
+      unit: {
+        type: "string",
+        enum: ["celsius", "fahrenheit"],
+        description: "The unit of temperature to return"
+      }
+    },
+    required: ["location"]
   }
 ) do |location:, unit: 'celsius'|
   # Implement your application logic here
@@ -71,6 +81,9 @@ weather_agent.chat("What's the weather like in London?") do |response_chunk|
   print response_chunk 
 end
 ```
+
+The `parameters` hash is passed directly through to OpenAI's API. You can see details about how to define parameters in [OpenAI's documentation for defining functions](https://platform.openai.com/docs/guides/function-calling#defining-functions).
+
 
 ### Multi-Agent System
 
@@ -100,6 +113,10 @@ agency.chat([
   print response_chunk
 end
 ```
+
+## Examples
+
+A few working examples are in the `examples/` directory. If you have `OPENAI_API_KEY` set in the environment, you can run the examples with with `bundle exec ruby examples/<example file>.rb` to get a taste of Bristow.
 
 ## Configuration
 

--- a/bristow.gemspec
+++ b/bristow.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "ruby-openai", "~> 7.0.0"
 
+  spec.add_development_dependency "debug", "~> 1.10"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "vcr", "~> 6.0"

--- a/examples/function_calls.rb
+++ b/examples/function_calls.rb
@@ -9,8 +9,19 @@ weather = Bristow::Function.new(
   name: "get_weather",
   description: "Get the current weather for a location",
   parameters: {
-    location: String,
-    unit: String
+    type: "object",
+    properties: {
+      location: {
+        type: "string",
+        description: "The city and state, e.g. San Francisco, CA"
+      },
+      unit: {
+        type: "string",
+        enum: ["celsius", "fahrenheit"],
+        description: "The unit of temperature to return"
+      }
+    },
+    required: [:location]
   }
 ) do |location:, unit: 'celsius'|
   # Your weather API call here

--- a/lib/bristow/agencies/supervisor.rb
+++ b/lib/bristow/agencies/supervisor.rb
@@ -25,9 +25,6 @@ module Bristow
         # Convert string message to proper format
         messages = [{ role: "user", content: messages }] if messages.is_a?(String)
         
-        # Convert array of strings to proper format
-        messages = messages.map { |msg| msg.is_a?(String) ? { role: "user", content: msg } : msg } if messages.is_a?(Array)
-
         supervisor.chat(messages, &block)
       end
     end

--- a/lib/bristow/agent.rb
+++ b/lib/bristow/agent.rb
@@ -25,35 +25,13 @@ module Bristow
 
     def functions_for_openai
       functions.map do |function|
-        {
-          name: function.name,
-          description: function.description,
-          parameters: {
-            type: "object",
-            properties: function.parameters.transform_values { |type| parameter_type_for(type) },
-            required: function.parameters.keys.map(&:to_s)
-          }
-        }
+        function.to_openai_schema
       end
     end
 
     def chat(messages, &block)
       # Convert string message to proper format
       messages = [{ role: "user", content: messages }] if messages.is_a?(String)
-
-      # Convert array to array of hashes
-      messages = if messages.is_a?(Array)
-        messages.map do |msg|
-          case msg
-          when Hash
-            msg.transform_keys(&:to_sym)
-          else
-            raise ArgumentError, "Invalid message format: #{msg.inspect}"
-          end
-        end
-      else
-        messages
-      end
 
       messages = messages.dup
       messages.unshift(system_message_hash) if system_message

--- a/spec/bristow/agencies/supervisor_spec.rb
+++ b/spec/bristow/agencies/supervisor_spec.rb
@@ -56,14 +56,6 @@ RSpec.describe Bristow::Agencies::Supervisor do
       expect(response.join).not_to be_empty
     end
 
-    it "accepts an array of string messages", vcr: { cassette_name: "bristow_agencies_supervisor_chat_accepts_array_of_strings" } do
-      response = []
-      agency.chat(["Hello", "What's the weather in New York?"]) do |part|
-        response << part
-      end
-      expect(response.join).not_to be_empty
-    end
-
     it "raises error when supervisor not set" do
       agency.supervisor = nil
       expect {
@@ -74,11 +66,6 @@ RSpec.describe Bristow::Agencies::Supervisor do
     it "handles array and non-array messages" do
       # String message
       agency.chat("Hello", &block)
-      expect(@streamed_parts).not_to be_empty
-
-      # Array of strings
-      @streamed_parts = []
-      agency.chat(["Hello"], &block)
       expect(@streamed_parts).not_to be_empty
 
       # Array of hashes

--- a/spec/bristow/agent_spec.rb
+++ b/spec/bristow/agent_spec.rb
@@ -63,14 +63,6 @@ RSpec.describe Bristow::Agent do
       expect(response.join).not_to be_empty
     end
 
-    it "accepts an array of string messages", vcr: true do
-      response = []
-      agent.chat(["Hello", "How are you?"]) do |part|
-        response << part
-      end
-      expect(response.join).not_to be_empty
-    end
-
     it "updates chat history", vcr: true do
       expect {
         agent.chat(messages, &block)

--- a/spec/bristow/function_spec.rb
+++ b/spec/bristow/function_spec.rb
@@ -3,7 +3,25 @@
 RSpec.describe Bristow::Function do
   let(:name) { "test_function" }
   let(:description) { "A test function" }
-  let(:parameters) { { param1: String, param2: Integer, param3: { type: String, optional: true } } }
+  let(:parameters) do
+    {
+      properties: {
+        param1: {
+          type: "string",
+          description: "First parameter"
+        },
+        param2: {
+          type: "integer",
+          description: "Second parameter"
+        },
+        param3: {
+          type: "string",
+          description: "Optional third parameter"
+        }
+      },
+      required: ["param1", "param2"]
+    }
+  end
   let(:block) { ->(param1:, param2:, param3: nil) { { result: [param1, param2, param3] } } }
 
   subject(:function) do
@@ -47,93 +65,17 @@ RSpec.describe Bristow::Function do
     it "raises an error for missing required parameters" do
       expect {
         function.call(param1: "test")
-      }.to raise_error(ArgumentError, /missing keyword: :param2/)
-    end
-
-    it "raises an error for invalid parameter types" do
-      expect {
-        function.call(param1: 123, param2: "invalid")
-      }.to raise_error(TypeError, "param1 must be a String")
+      }.to raise_error(ArgumentError, /missing keyword: param2/)
     end
   end
 
   describe "#to_openai_schema" do
-    it "returns the function schema in OpenAI format" do
+    it "returns the correct schema format" do
       schema = function.to_openai_schema
       expect(schema).to eq({
         name: name,
         description: description,
-        parameters: {
-          type: "object",
-          properties: {
-            param1: { type: "string" },
-            param2: { type: "integer" },
-            param3: { type: "string" }
-          },
-          required: [:param1, :param2]
-        }
-      })
-    end
-
-    it "handles complex type definitions" do
-      function = described_class.new(
-        name: name,
-        description: description,
-        parameters: {
-          str: String,
-          int: Integer,
-          float: Float,
-          bool: TrueClass,
-          hash: Hash,
-          complex: { type: String, optional: true },
-          custom: Object
-        }
-      ) { |**kwargs| kwargs }
-
-      schema = function.to_openai_schema
-      expect(schema[:parameters][:properties]).to eq({
-        str: { type: "string" },
-        int: { type: "integer" },
-        float: { type: "number" },
-        bool: { type: "boolean" },
-        hash: { type: "object" },
-        complex: { type: "string" },
-        custom: { type: "string" }
-      })
-      expect(schema[:parameters][:required]).to match_array([:str, :int, :float, :bool, :hash, :custom])
-    end
-
-    it "handles unknown array types" do
-      function = described_class.new(
-        name: name,
-        description: description,
-        parameters: {
-          arr: [String, Integer],
-          unknown: [Object, Class]
-        }
-      ) { |**kwargs| kwargs }
-
-      schema = function.to_openai_schema
-      expect(schema[:parameters][:properties]).to eq({
-        arr: { type: "string" },
-        unknown: { type: "string" }
-      })
-    end
-
-    it "handles unknown types" do
-      function = described_class.new(
-        name: name,
-        description: description,
-        parameters: {
-          unknown: Class,
-          symbol: Symbol
-        }
-      ) { |**kwargs| kwargs }
-
-      schema = function.to_openai_schema
-      expect(schema[:parameters][:properties]).to eq({
-        unknown: { type: "string" },
-        symbol: { type: "string" }
+        parameters: parameters
       })
     end
   end


### PR DESCRIPTION
Dropping the API abstraction for function params. Punting on a custom API until some future date (maybe).

For now, just going to pass user's parameter definitions directly to OpenAI.
