### PR TITLE
Refactor API to be inheritance based

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/examples/agency.rb
+++ b/examples/agency.rb
@@ -1,23 +1,27 @@
-require_relative "../lib/bristow"
+require_relative '../lib/bristow'
 
-pirate_talker = Bristow::Agent.new(
-    name: "PirateSpeaker",
-    description: "Agent for translating input to pirate-speak",
-    system_message: 'Given a text, you will translate it to pirate-speak.',
-)
-
-travel_agent = Bristow::Agent.new(
-    name: "TravelAgent",
-    description: "Agent for planning trips",
-    system_message: 'Given a destination, you will plan a trip. You will respond with an itinerary that includes dates, times, and locations only.',
-)
-
-agency = Bristow::Agencies::Supervisor.create(agents: [pirate_talker, travel_agent])
-
-messages = agency.chat([
-    { role: "user", content: "I want to go to New York. Please plan my trip and tell me about it as if you were a pirate." }
-]) do |part|
-    print part
+class PirateTalker < Bristow::Agent
+  name "PirateSpeaker"
+  description "Agent for translating input to pirate-speak"
+  system_message 'Given a text, you will translate it to pirate-speak.'
 end
 
-puts messages
+class TravelAgent < Bristow::Agent
+  name "TravelAgent"
+  description "Agent for planning trips"
+  system_message 'Given a destination, you will plan a trip. You will respond with an itinerary that includes dates, times, and locations only.'
+end
+
+class PirateTravelAgency < Bristow::Agencies::Supervisor
+  agents [PirateTalker, TravelAgent]
+  custom_instructions "Once you know the destination, you should call the TravelAgent to plan the itenerary, then translate the itenerary to pirate-speak using PirateSpeaker before returning it to the user."
+end
+
+begin
+  messages = PirateTravelAgency.chat("I want to go to New York") do |part|
+      print part
+  end
+rescue SystemStackError => e
+  puts e.backtrace.join("\n")
+end
+pp messages

--- a/examples/basic_agent.rb
+++ b/examples/basic_agent.rb
@@ -1,15 +1,22 @@
-require_relative "../lib/bristow"
+require_relative '../lib/bristow'
 
 Bristow.configure do |config|
-    config.default_model = 'gpt-4o-mini'
+    config.model = 'gpt-4o-mini'
 end
 
-sydney = Bristow::Agent.new(
-  name: 'Sydney',
-  description: 'Agent for telling spy stories',
-  system_message: 'Given a topic, you will tell a brief spy story',
-)
+class Sydney < Bristow::Agent
+  name 'Sydney'
+  description 'Agent for telling spy stories'
+  system_message 'Given a topic, you will tell a brief spy story'
+end
 
-sydney.chat([{role: 'user', content: 'Cold war era Berlin'}]) do |part|
-  print part
+sydney = Sydney.new
+
+begin
+  sydney.chat([{role: 'user', content: 'Cold war era Berlin'}]) do |part|
+    print part
+  end
+
+rescue SystemStackError => e
+  puts e.backtrace.join("\n")
 end

--- a/examples/function_calls.rb
+++ b/examples/function_calls.rb
@@ -1,14 +1,14 @@
-require_relative "../lib/bristow"
+require_relative '../lib/bristow'
 
 Bristow.configure do |config|
-    config.default_model = 'gpt-4o-mini'
+    config.model = 'gpt-4o-mini'
 end
 
 # Define functions that GPT can call
-weather = Bristow::Function.new(
-  name: "get_weather",
-  description: "Get the current weather for a location",
-  parameters: {
+class WeatherLookup < Bristow::Function
+  name "get_weather"
+  description "Get the current weather for a location"
+  parameters ({
     type: "object",
     properties: {
       location: {
@@ -22,25 +22,24 @@ weather = Bristow::Function.new(
       }
     },
     required: [:location]
-  }
-) do |location:, unit: 'celsius'|
-  # Your weather API call here
-  { temperature: 22, unit: unit }
+  })
+
+  def perform(location:, unit: 'celsius')
+    # Your weather API call here
+    { temperature: 22, unit: unit }
+  end
 end
 
 # Create an agent with these functions
-weather_agent = Bristow::Agent.new(
-  name: "WeatherAssistant",
-  description: "Helps with weather-related queries",
-  functions: [weather]
-)
+class WeatherAgent < Bristow::Agent
+  name "WeatherAssistant"
+  description "Helps with weather-related queries"
+  system_message "You are a helpful weather assistant. You'll be asked about the weather, and should use the get_weather function to respond."
+  functions [WeatherLookup]
+end
 
 # Start a conversation
-messages = [
-  { "role" => "user", "content" => "What's the weather like in London?" }
-]
-
-messages_from_chat = weather_agent.chat(messages) do |part|
+messages = WeatherAgent.chat("What's the weather like in London?") do |part|
   print part
 end
 

--- a/lib/bristow.rb
+++ b/lib/bristow.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
+require 'debug'
+require 'openai'
+require 'logger'
+require 'json'
 
 require_relative "bristow/version"
+require_relative "bristow/helpers/sgetter"
+require_relative "bristow/helpers/delegate"
 require_relative "bristow/configuration"
 require_relative "bristow/function"
+require_relative "bristow/functions/delegate"
 require_relative "bristow/agent"
 require_relative "bristow/agents/supervisor"
 require_relative "bristow/agency"

--- a/lib/bristow/agencies/supervisor.rb
+++ b/lib/bristow/agencies/supervisor.rb
@@ -1,30 +1,26 @@
 module Bristow
   module Agencies
     class Supervisor < Agency
-      attr_accessor :supervisor
+      attr_reader :supervisor
 
-      def self.create(agents: [])
-        agency = new(agents: agents)
-        supervisor = Agents::Supervisor.new(
-          available_agents: agents,
-          agency: agency
-        )
-        agency.supervisor = supervisor
-        agency.agents << supervisor
-        agency
-      end
+      sgetter :custom_instructions, default: nil
 
-      def initialize(agents: [])
+      def initialize(agents: self.class.agents.dup)
+        @custom_instructions = self.class.custom_instructions
         @agents = agents
-        @supervisor = nil  # Will be set by create
+        @supervisor = Agents::Supervisor.new(
+          child_agents: agents,
+          agency: self,
+          custom_instructions: custom_instructions
+        )
       end
 
       def chat(messages, &block)
-        raise "No supervisor set" unless supervisor
+        raise "Supervisor not set" unless supervisor
 
         # Convert string message to proper format
         messages = [{ role: "user", content: messages }] if messages.is_a?(String)
-        
+
         supervisor.chat(messages, &block)
       end
     end

--- a/lib/bristow/agency.rb
+++ b/lib/bristow/agency.rb
@@ -1,17 +1,26 @@
 module Bristow
   class Agency
-    attr_reader :agents
+    include Bristow::Sgetter
 
-    def initialize(agents: [])
+    sgetter :agents, default: []
+
+    def initialize(agents: self.class.agents.dup)
       @agents = agents
     end
 
+    def self.chat(...)
+      new.chat(...)
+    end
+
     def chat(messages, &block)
-      raise NotImplementedError, "Agency#chat must be implemented by a subclass"
+      raise NotImplementedError, "#{self.class.name}#chat must be implemented"
     end
 
     def find_agent(name)
-      agents.find { |agent| agent.name == name }
+      agent = agents.find { |agent| agent_name(agent) == name }
+      return nil unless agent
+      
+      agent.is_a?(Class) ? agent.new : agent
     end
 
     protected
@@ -19,6 +28,12 @@ module Bristow
     def call_agent(agent, messages, &block)
       response = agent.chat(messages, &block)
       response.last # Return just the last message
+    end
+
+    private
+
+    def agent_name(agent)
+      agent.is_a?(Class) ? agent.name : agent.class.name
     end
   end
 end

--- a/lib/bristow/agents/supervisor.rb
+++ b/lib/bristow/agents/supervisor.rb
@@ -1,17 +1,37 @@
+# frozen_string_literal: true
+
 module Bristow
   module Agents
     class Supervisor < Agent
-      attr_accessor :agency
+      attr_reader :agency
 
-      def initialize(available_agents:, agency: nil, name: "Supervisor", description: "A supervisor agent that coordinates between specialized agents", model: Bristow.configuration.default_model)
-        super(
-          name: name,
-          description: description,
-          system_message: build_system_message(available_agents),
-          functions: [delegate_function],
-          model: model
-        )
+      name "Supervisor"
+      description "A supervisor agent that coordinates between specialized agents"
+      system_message <<~MESSAGE
+        You are a supervisor agent that coordinates between specialized agents.
+        Your role is to:
+        1. Understand the user's request
+        2. Choose the most appropriate agent to handle it
+        3. Delegate using the delegate_to function
+        4. Review the agent's response
+        5. Either return the response to the user or delegate to another agent
+
+        After receiving a response, you can either:
+        1. Return it to the user if it fully answers their request
+        2. Delegate to another agent if more work is needed
+        3. Add your own clarification or summary if needed
+      MESSAGE
+
+      sgetter :custom_instructions, default: nil
+
+      def initialize(child_agents:, agency:, custom_instructions: nil)
+        super()
+        @custom_instructions = custom_instructions || self.class.custom_instructions
+        @system_message = build_system_message(child_agents)
         @agency = agency
+        @custom_instructions = custom_instructions || self.class.custom_instructions
+        agency.agents << self
+        functions << Functions::Delegate.new(self, agency)
       end
 
       private
@@ -22,55 +42,15 @@ module Bristow
         end.join("\n")
 
         <<~MESSAGE
-          You are a supervisor agent that coordinates between specialized agents.
-          Your role is to:
-          1. Understand the user's request
-          2. Choose the most appropriate agent to handle it
-          3. Delegate using the delegate_to function
-          4. Review the agent's response
-          5. Either return the response to the user or delegate to another agent
+          #{self.class.system_message}
+
+          #{custom_instructions.nil? ? "" : custom_instructions}
 
           Available agents:
           #{agent_descriptions}
 
           Always use the delegate_to function to work with other agents.
-          After receiving a response, you can either:
-          1. Return it to the user if it fully answers their request
-          2. Delegate to another agent if more work is needed
-          3. Add your own clarification or summary if needed
         MESSAGE
-      end
-
-      def delegate_function
-        Function.new(
-          name: "delegate_to",
-          description: "Delegate a task to a specialized agent",
-          parameters: {
-            properties: {
-              agent_name: {
-                type: "string",
-                description: "The name of the agent to delegate to"
-              },
-              message: {
-                type: "string",
-                description: "The instructions for the agent being delegated to"
-              }
-            }
-          }
-        ) do |agent_name:, message:|
-          raise "No agency set for supervisor" unless agency
-
-          if agent_name == name
-            { error: "Cannot delegate to self" }
-          else
-            agent = agency.find_agent(agent_name)
-            raise ArgumentError, "Agent #{agent_name} not found" unless agent
-
-            Bristow.configuration.logger.info("Delegating to #{agent_name}: #{message}")
-            response = agent.chat([{ "role" => "user", "content" => message }])
-            { response: response.last["content"] }
-          end
-        end
       end
     end
   end

--- a/lib/bristow/configuration.rb
+++ b/lib/bristow/configuration.rb
@@ -1,6 +1,3 @@
-require 'logger'
-require 'openai'
-
 module Bristow
   class Configuration
     attr_accessor :openai_api_key, :default_model, :logger

--- a/lib/bristow/configuration.rb
+++ b/lib/bristow/configuration.rb
@@ -1,11 +1,11 @@
 module Bristow
   class Configuration
-    attr_accessor :openai_api_key, :default_model, :logger
+    attr_accessor :openai_api_key, :model, :logger
     attr_reader :client
 
     def initialize
       @openai_api_key = ENV['OPENAI_API_KEY']
-      @default_model = 'gpt-4o-mini'
+      @model = 'gpt-4o-mini'
       @logger = Logger.new(STDOUT)
       reset_client
     end

--- a/lib/bristow/functions/delegate.rb
+++ b/lib/bristow/functions/delegate.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Bristow
+  module Functions
+    class Delegate < Function
+      def self.name
+        "delegate_to"
+      end
+
+      def self.description
+        "Delegate a task to a specialized agent"
+      end
+
+      def self.parameters
+        {
+          type: "object",
+          properties: {
+            agent_name: {
+              type: "string",
+              description: "The name of the agent to delegate to"
+            },
+            message: {
+              type: "string",
+              description: "The instructions for the agent being delegated to"
+            }
+          },
+          required: ["agent_name", "message"]
+        }
+      end
+
+      def name
+        self.class.name
+      end
+
+      def description
+        self.class.description
+      end
+
+      def parameters
+        self.class.parameters
+      end
+
+      def initialize(agent, agency)
+        raise ArgumentError, "Agent must not be nil" if agent.nil?
+
+        @agent = agent
+        @agency = agency
+      end
+
+      def agency=(agency)
+        @agency = agency
+      end
+
+      def perform(agent_name:, message:)
+        raise "Agency not set" if @agency.nil?
+
+        if agent_name == @agent.name
+          { error: "Cannot delegate to self" }
+        else
+          agent = @agency.find_agent(agent_name)
+          raise ArgumentError, "Agent #{agent_name} not found" unless agent
+
+          Bristow.configuration.logger.info("Delegating to #{agent_name}: #{message}")
+          response = agent.chat([{ "role" => "user", "content" => message }])
+          last_message = response&.last
+          { response: last_message&.[]("content") }
+        end
+      end
+    end
+  end
+end

--- a/lib/bristow/helpers/delegate.rb
+++ b/lib/bristow/helpers/delegate.rb
@@ -1,0 +1,17 @@
+module Bristow
+  module Delegate
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def delegate(*methods, to:)
+        methods.each do |method|
+          define_method(method) do
+            send(to).send(method)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/bristow/helpers/sgetter.rb
+++ b/lib/bristow/helpers/sgetter.rb
@@ -1,0 +1,42 @@
+# A helper to define a getter/setter method
+# This will let you define a class level getter/setter method with an instance reader
+#
+# Example:
+# class Agent
+#   include Bristow::Sgetter
+#   sgetter :name
+#   sgetter :model, default: -> { Bristow.configuration.model }
+# end
+#
+# class Sydney < Agent
+#   name 'Sydney'
+# end
+#
+# sydney = Sydney.new
+# sydney.name # => 'Sydney'
+module Bristow
+  module Sgetter
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+
+    module ClassMethods
+      def sgetter(attr, default: nil)
+        # Define the method that allows for both getter/setter syntax
+        define_singleton_method(attr) do |val = nil|
+          if val.nil?
+            return instance_variable_get("@#{attr}") if instance_variable_defined?("@#{attr}")
+            default.respond_to?(:call) ? default.call : default
+          else
+            instance_variable_set("@#{attr}", val)
+          end
+        end
+
+        # Instance-level reader
+        define_method(attr) do
+          instance_variable_get("@#{attr}")
+        end
+      end
+    end
+  end
+end

--- a/spec/bristow/agencies/supervisor_spec.rb
+++ b/spec/bristow/agencies/supervisor_spec.rb
@@ -1,77 +1,129 @@
 # frozen_string_literal: true
 
 RSpec.describe Bristow::Agencies::Supervisor do
-  let(:weather_agent) do
-    Bristow::Agent.new(
-      name: "WeatherBot",
-      description: "Handles weather queries"
-    )
+  before(:all) do
+    @test_function = Class.new(Bristow::Function) do
+      name "test_function"
+      description "A test function"
+      parameters({
+        type: "object",
+        properties: {
+          param: {
+            type: "string",
+            description: "A test parameter"
+          }
+        },
+        required: ["param"]
+      })
+
+      def self.perform(param:)
+        { result: param }
+      end
+    end
+
+    @test_agent_class = Class.new(Bristow::Agent) do
+      name "TestAgent"
+      description "A test agent"
+      system_message "You are a test agent"
+      functions [@test_function]
+    end
   end
 
-  let(:math_agent) do
-    Bristow::Agent.new(
-      name: "MathBot",
-      description: "Handles math calculations"
-    )
+  let(:test_agency) do
+    test_agent_class = @test_agent_class
+    Class.new(described_class) do
+      agents [test_agent_class]
+    end
   end
 
-  let(:agents) { [weather_agent, math_agent] }
+  subject(:agency) { test_agency.new }
 
   describe ".create" do
-    subject(:agency) { described_class.create(agents: agents) }
-
     it "creates an agency with the given agents" do
-      expect(agency.agents).to include(weather_agent, math_agent)
+      expect(test_agency.agents).to eq([@test_agent_class])
     end
 
     it "creates and sets up a supervisor" do
       expect(agency.supervisor).to be_a(Bristow::Agents::Supervisor)
-      expect(agency.supervisor.agency).to eq(agency)
     end
   end
 
-  describe "#chat", :vcr do
-    subject(:agency) { described_class.create(agents: agents) }
-    let(:messages) { [{ "role" => "user", "content" => "Hello" }] }
-    let(:block) { proc { |part| @streamed_parts ||= []; @streamed_parts << part } }
+  describe "#chat" do
+    let(:messages) { [{ role: "user", content: "Hello" }] }
+    let(:block) { proc { |part| @streamed_parts << part } }
+
+    before do
+      @streamed_parts = []
+    end
 
     it "delegates chat to supervisor" do
+      expect(agency.supervisor).to receive(:chat).with(messages, &block)
       agency.chat(messages, &block)
-      expect(@streamed_parts).not_to be_empty
     end
 
-    it "delegates chat to supervisor", vcr: { cassette_name: "bristow_agencies_supervisor_chat_delegates_chat_to_supervisor_base" } do
-      response = []
-      agency.chat([{ role: "user", content: "What's the weather in New York?" }]) do |part|
-        response << part
-      end
-      expect(response.join).not_to be_empty
+    it "delegates chat to supervisor" do
+      expect(agency.supervisor).to receive(:chat).with(messages, &block)
+      agency.chat(messages, &block)
     end
 
-    it "accepts a string message", vcr: { cassette_name: "bristow_agencies_supervisor_chat_accepts_string_message" } do
-      response = []
-      agency.chat("What's the weather in New York?") do |part|
-        response << part
-      end
-      expect(response.join).not_to be_empty
+    it "accepts a string message" do
+      expect(agency.supervisor).to receive(:chat).with([{ role: "user", content: "Hello" }], &block)
+      agency.chat("Hello", &block)
     end
 
     it "raises error when supervisor not set" do
-      agency.supervisor = nil
+      agency.instance_variable_set(:@supervisor, nil)
       expect {
         agency.chat(messages, &block)
-      }.to raise_error(/No supervisor set/)
+      }.to raise_error(RuntimeError, /Supervisor not set/)
     end
 
     it "handles array and non-array messages" do
-      # String message
+      expect(agency.supervisor).to receive(:chat).with([{ role: "user", content: "Hello" }], &block)
       agency.chat("Hello", &block)
-      expect(@streamed_parts).not_to be_empty
 
-      # Array of hashes
-      @streamed_parts = []
-      agency.chat([{ "role" => "user", "content" => "Hello" }], &block)
-      expect(@streamed_parts).not_to be_empty
+      expect(agency.supervisor).to receive(:chat).with(messages, &block)
+      agency.chat(messages, &block)
+    end
+  end
+
+  describe "delegation" do
+    let(:delegate_fn) { agency.supervisor.functions.find { |f| f.name == "delegate_to" } }
+
+    it "delegates to the specified agent" do
+      response = delegate_fn.call(
+        agent_name: "TestAgent",
+        message: "Hello"
+      )
+      expect(response).to match(response: "Hello! How can I assist you today?")
+    end
+
+    it "raises error when agency not set" do
+      delegate_fn.instance_variable_set(:@agency, nil)
+      expect {
+        delegate_fn.call(
+          agent_name: "TestAgent",
+          message: "Hello"
+        )
+      }.to raise_error(RuntimeError, /Agency not set/)
+    end
+
+    it "raises error when agent not found" do
+      expect {
+        delegate_fn.call(
+          agent_name: "UnknownBot",
+          message: "Hello"
+        )
+      }.to raise_error(ArgumentError, /Agent UnknownBot not found/)
+    end
+
+    it "prevents self-delegation" do
+      result = delegate_fn.call(
+        agent_name: "Supervisor",
+        message: "Hello"
+      )
+
+      expect(result).to match(error: "Cannot delegate to self")
     end
   end
 end

--- a/spec/bristow/agencies/supervisor_spec.rb
+++ b/spec/bristow/agencies/supervisor_spec.rb
@@ -90,7 +90,7 @@ RSpec.describe Bristow::Agencies::Supervisor do
   describe "delegation" do
     let(:delegate_fn) { agency.supervisor.functions.find { |f| f.name == "delegate_to" } }
 
-    it "delegates to the specified agent" do
+    it "delegates to the specified agent", :vcr do
       response = delegate_fn.call(
         agent_name: "TestAgent",
         message: "Hello"

--- a/spec/bristow/agency_spec.rb
+++ b/spec/bristow/agency_spec.rb
@@ -1,43 +1,55 @@
 # frozen_string_literal: true
 
 RSpec.describe Bristow::Agency do
-  let(:agent1) do
-    Bristow::Agent.new(
-      name: "Agent1",
-      description: "First test agent"
-    )
-  end
-
-  let(:agent2) do
-    Bristow::Agent.new(
-      name: "Agent2",
-      description: "Second test agent"
-    )
-  end
-
-  subject(:agency) do
-    described_class.new(agents: [agent1, agent2])
-  end
-
-  describe "#initialize" do
-    it "creates an agency with the given agents" do
-      expect(agency.agents).to contain_exactly(agent1, agent2)
+  before(:all) do
+    @test_agent1_class = Class.new(Bristow::Agent) do
+      name "TestAgent1"
+      description "A test agent"
     end
 
-    it "defaults to empty agents array" do
-      agency = described_class.new
-      expect(agency.agents).to be_empty
+    @test_agent2_class = Class.new(Bristow::Agent) do
+      name "TestAgent2"
+      description "Another test agent"
+    end
+  end
+
+  let(:test_agency) do
+    test_agent1_class = @test_agent1_class
+    test_agent2_class = @test_agent2_class
+    test_agent3 = @test_agent1_class.new
+    Class.new(described_class) do
+      agents [test_agent1_class, test_agent2_class, test_agent3]
+    end
+  end
+
+  subject(:agency) { test_agency.new }
+
+  describe ".agents" do
+    it "sets and gets the agents" do
+      agents = test_agency.agents
+      expect(agents.length).to eq(3)
+      expect(agents[0]).to eq(@test_agent1_class)
+      expect(agents[1]).to eq(@test_agent2_class)
+      expect(agents[2]).to be_a(@test_agent1_class)
+    end
+
+    it "defaults to empty array" do
+      agency_class = Class.new(described_class)
+      expect(agency_class.agents).to eq([])
     end
   end
 
   describe "#find_agent" do
-    it "finds an agent by name" do
-      expect(agency.find_agent("Agent1")).to eq(agent1)
-      expect(agency.find_agent("Agent2")).to eq(agent2)
+    it "finds an agent by name from a class" do
+      expect(agency.find_agent("TestAgent1")).to be_a(@test_agent1_class)
+    end
+
+    it "finds an agent by name from an instance" do
+      expect(agency.find_agent("TestAgent1")).to be_a(@test_agent1_class)
     end
 
     it "returns nil for unknown agent" do
-      expect(agency.find_agent("Unknown")).to be_nil
+      expect(agency.find_agent("UnknownAgent")).to be_nil
     end
   end
 
@@ -50,12 +62,15 @@ RSpec.describe Bristow::Agency do
   end
 
   describe "#call_agent" do
-    let(:messages) { [{ "role" => "user", "content" => "test" }] }
-    let(:block) { proc { |part| @streamed_parts ||= []; @streamed_parts << part } }
+    it "calls the agent with messages and block" do
+      messages = [{ role: "user", content: "Hello" }]
+      block = proc { |part| @streamed_parts << part }
+      @streamed_parts = []
 
-    it "calls the agent with messages and block", :vcr do
-      expect(agent1).to receive(:chat).with(messages, &block)
-      agency.send(:call_agent, agent1, messages, &block)
+      agent = agency.find_agent("TestAgent1")
+      expect(agent).to receive(:chat).with(messages, &block)
+
+      agency.send(:call_agent, agent, messages, &block)
     end
   end
 end

--- a/spec/bristow/agents/supervisor_spec.rb
+++ b/spec/bristow/agents/supervisor_spec.rb
@@ -1,68 +1,167 @@
 # frozen_string_literal: true
 
 RSpec.describe Bristow::Agents::Supervisor do
-  let(:weather_agent) do
-    Bristow::Agent.new(
-      name: "WeatherBot",
-      description: "Handles weather queries",
-      functions: [
-        Bristow::Function.new(
-          name: "get_weather",
-          description: "Get weather",
-          parameters: { location: String }
-        ) { |location:| { weather: "sunny" } }
-      ]
-    )
+  before(:all) do
+    @test_agent_class = Class.new(Bristow::Agent) do
+      name "TestAgent"
+      description "A test agent"
+      system_message "You are a test agent"
+    end
   end
 
-  let(:math_agent) do
-    Bristow::Agent.new(
-      name: "MathBot",
-      description: "Handles math calculations"
-    )
+  let(:agency) { Bristow::Agency.new }
+  let(:test_agent) { @test_agent_class.new }
+  let(:child_agents) { [test_agent] }
+  let(:custom_instructions) { "Custom supervisor instructions" }
+  subject(:supervisor) { described_class.new(child_agents: child_agents, agency: agency, custom_instructions: custom_instructions) }
+
+  before do
+    # Add test agent to agency
+    agency.agents << test_agent
   end
 
-  let(:agency) { Bristow::Agencies::Supervisor.create(agents: available_agents) }
-  let(:available_agents) { [weather_agent, math_agent] }
+  describe ".class_methods" do
+    it "has correct class-level attributes" do
+      expect(described_class.name).to eq("Supervisor")
+      expect(described_class.description).to eq("A supervisor agent that coordinates between specialized agents")
+      expect(described_class.custom_instructions).to be_nil
+    end
 
-  subject(:supervisor) { agency.supervisor }
+    it "allows setting class-level custom instructions" do
+      old_instructions = described_class.custom_instructions
+      described_class.custom_instructions("Default instructions")
+      expect(described_class.custom_instructions).to eq("Default instructions")
+      described_class.custom_instructions(old_instructions)
+    end
+  end
 
   describe "#initialize" do
     it "creates a supervisor with available agents" do
       expect(supervisor.name).to eq("Supervisor")
-      expect(supervisor.description).to match(/coordinates between specialized agents/)
+      expect(described_class.description).to eq("A supervisor agent that coordinates between specialized agents")
     end
 
     it "includes agent descriptions in system message" do
-      expect(supervisor.instance_variable_get(:@system_message))
-        .to include("WeatherBot: Handles weather queries")
-        .and include("MathBot: Handles math calculations")
+      expect(supervisor.system_message).to match(/Available agents:\n- TestAgent: TestAgent\n/)
+    end
+
+    it "includes custom instructions in system message" do
+      expect(supervisor.system_message).to include(custom_instructions)
+    end
+
+    it "uses class-level custom instructions when none provided" do
+      old_instructions = described_class.custom_instructions
+      described_class.custom_instructions("Default instructions")
+      supervisor_without_instructions = described_class.new(child_agents: child_agents, agency: agency)
+      expect(supervisor_without_instructions.system_message).to include("Default instructions")
+      described_class.custom_instructions(old_instructions)
     end
 
     it "sets up delegation function" do
-      expect(supervisor.functions.first.name).to eq("delegate_to")
+      delegate_fn = supervisor.functions.first
+      expect(delegate_fn.name).to eq("delegate_to")
+      expect(delegate_fn.parameters[:properties]).to include(:agent_name, :message)
+    end
+
+    it "adds itself to the agency" do
+      expect(agency.agents).to include(supervisor)
     end
   end
 
-  describe "delegation", :vcr do
+  describe "#chat" do
+    let(:client) { instance_double(OpenAI::Client) }
+    let(:messages) { [{ role: "user", content: "Please help me" }] }
+    let(:function_call_response) do
+      {
+        "choices" => [{
+          "message" => {
+            "role" => "assistant",
+            "function_call" => {
+              "name" => "delegate_to",
+              "arguments" => JSON.dump({
+                "agent_name" => "TestAgent",
+                "message" => "How can I help you?"
+              })
+            }
+          }
+        }]
+      }
+    end
+    let(:final_response) do
+      {
+        "choices" => [{
+          "message" => {
+            "role" => "assistant",
+            "content" => "I've helped you with that"
+          }
+        }]
+      }
+    end
+
+    before do
+      allow(Bristow.configuration).to receive(:client).and_return(client)
+      allow(client).to receive(:chat).and_return(function_call_response, final_response)
+      allow(test_agent).to receive(:chat).and_return([{ "role" => "assistant", "content" => "Test response" }])
+    end
+
+    it "accepts string messages" do
+      messages = supervisor.chat("Help me")
+      expect(messages).to include(
+        hash_including("role" => "assistant", "content" => "I've helped you with that")
+      )
+    end
+
+    it "handles API errors" do
+      allow(client).to receive(:chat).and_raise(Faraday::BadRequestError.new(nil, { body: "error" }))
+      expect {
+        supervisor.chat("Help me")
+      }.to raise_error(Faraday::BadRequestError)
+    end
+  end
+
+  describe "delegation" do
     let(:delegate_fn) { supervisor.functions.first }
 
+    before do
+      stub_request(:post, "https://api.openai.com/v1/chat/completions")
+        .with(
+          headers: {
+            'Content-Type' => 'application/json',
+            'Authorization' => "Bearer #{ENV['OPENAI_API_KEY']}"
+          }
+        )
+        .to_return(
+          status: 200,
+          headers: { 'Content-Type' => 'application/json' },
+          body: {
+            choices: [{
+              message: {
+                role: "assistant",
+                content: "Test response"
+              }
+            }]
+          }.to_json
+        )
+
+      allow(test_agent).to receive(:chat).and_return([{ "role" => "assistant", "content" => "Test response" }])
+    end
+
     it "delegates to the specified agent" do
-      result = delegate_fn.call(
-        agent_name: "WeatherBot",
-        message: "What's the weather in New York?"
+      response = delegate_fn.call(
+        agent_name: "TestAgent",
+        message: "Hello"
       )
-      expect(result[:response]).to include("sunny")
+      expect(response).to match(response: "Test response")
     end
 
     it "raises error when agency not set" do
-      supervisor.agency = nil
+      delegate_fn.agency = nil
       expect {
         delegate_fn.call(
-          agent_name: "WeatherBot",
-          message: "What's the weather?"
+          agent_name: "TestAgent",
+          message: "Hello"
         )
-      }.to raise_error(/No agency set/)
+      }.to raise_error(RuntimeError, /Agency not set/)
     end
 
     it "raises error when agent not found" do
@@ -79,7 +178,58 @@ RSpec.describe Bristow::Agents::Supervisor do
         agent_name: "Supervisor",
         message: "Hello"
       )
-      expect(result[:error]).to eq("Cannot delegate to self")
+
+      expect(result).to match(error: "Cannot delegate to self")
+    end
+
+    it "handles empty response from agent" do
+      allow(test_agent).to receive(:chat).and_return([])
+      response = delegate_fn.call(
+        agent_name: "TestAgent",
+        message: "Hello"
+      )
+      expect(response).to match(response: nil)
+    end
+
+    it "handles nil content in response" do
+      allow(test_agent).to receive(:chat).and_return([{ "role" => "assistant", "content" => nil }])
+      response = delegate_fn.call(
+        agent_name: "TestAgent",
+        message: "Hello"
+      )
+      expect(response).to match(response: nil)
+    end
+  end
+
+  describe "delegate function" do
+    let(:agency) { Bristow::Agency.new }
+    let(:supervisor) { described_class.new(child_agents: [], agency: agency) }
+
+    it "raises error when initialized with nil agent" do
+      expect {
+        Bristow::Functions::Delegate.new(nil, agency)
+      }.to raise_error(ArgumentError, /Agent must not be nil/)
+    end
+
+    it "has correct class-level attributes" do
+      delegate_class = Bristow::Functions::Delegate
+      expect(delegate_class.name).to eq("delegate_to")
+      expect(delegate_class.description).to eq("Delegate a task to a specialized agent")
+      expect(delegate_class.parameters).to include(
+        type: "object",
+        properties: hash_including(
+          agent_name: hash_including(type: "string"),
+          message: hash_including(type: "string")
+        ),
+        required: ["agent_name", "message"]
+      )
+    end
+
+    it "delegates class methods to instance methods" do
+      delegate = Bristow::Functions::Delegate.new(supervisor, agency)
+      expect(delegate.name).to eq(Bristow::Functions::Delegate.name)
+      expect(delegate.description).to eq(Bristow::Functions::Delegate.description)
+      expect(delegate.parameters).to eq(Bristow::Functions::Delegate.parameters)
     end
   end
 end

--- a/spec/bristow_spec.rb
+++ b/spec/bristow_spec.rb
@@ -5,11 +5,6 @@ RSpec.describe Bristow do
     expect(Bristow::VERSION).not_to be nil
   end
 
-  it "creates a supervisor agency" do
-    agency = Bristow::Agencies::Supervisor.create(agents: [])
-    expect(agency).to be_a(Bristow::Agencies::Supervisor)
-  end
-
   describe ".configure" do
     after(:each) do
       Bristow.reset_configuration!
@@ -18,11 +13,11 @@ RSpec.describe Bristow do
     it "allows setting configuration values" do
       Bristow.configure do |config|
         config.openai_api_key = "test-key"
-        config.default_model = "gpt-4"
+        config.model = "gpt-4"
       end
 
       expect(Bristow.configuration.openai_api_key).to eq("test-key")
-      expect(Bristow.configuration.default_model).to eq("gpt-4")
+      expect(Bristow.configuration.model).to eq("gpt-4")
     end
 
     it "resets the client when api key is updated" do
@@ -34,13 +29,13 @@ RSpec.describe Bristow do
     it "resets configuration to default values" do
       Bristow.configure do |config|
         config.openai_api_key = "test-key"
-        config.default_model = "gpt-4"
+        config.model = "gpt-4"
       end
 
       Bristow.reset_configuration!
 
       expect(Bristow.configuration.openai_api_key).to eq(ENV["OPENAI_API_KEY"])
-      expect(Bristow.configuration.default_model).to eq("gpt-4o-mini")
+      expect(Bristow.configuration.model).to eq("gpt-4o-mini")
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/bristow_agencies_supervisor_delegation_delegates_to_the_specified_agent.yml
+++ b/spec/fixtures/vcr_cassettes/bristow_agencies_supervisor_delegation_delegates_to_the_specified_agent.yml
@@ -1,0 +1,112 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/chat/completions
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","messages":[{"role":"system","content":"You
+        are a test agent"},{"role":"user","content":"Hello"}]}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sat, 01 Feb 2025 18:05:20 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Access-Control-Expose-Headers:
+      - X-Request-ID
+      Openai-Organization:
+      - "<OPENAI_ORG>"
+      Openai-Processing-Ms:
+      - '900'
+      Openai-Version:
+      - '2020-10-01'
+      X-Ratelimit-Limit-Requests:
+      - '10000'
+      X-Ratelimit-Limit-Tokens:
+      - '200000'
+      X-Ratelimit-Remaining-Requests:
+      - '9999'
+      X-Ratelimit-Remaining-Tokens:
+      - '199975'
+      X-Ratelimit-Reset-Requests:
+      - 8.64s
+      X-Ratelimit-Reset-Tokens:
+      - 7ms
+      X-Request-Id:
+      - "<REQUEST_ID>"
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - "<COOKIE>; path=/; expires=Sat, 01-Feb-25 18:35:20 GMT; domain=.api.openai.com;
+        HttpOnly; Secure; SameSite=None"
+      - _cfuvid=lMs0QzRbv0UwLWlp_g11Wb6GxJLq8BiQQs2BdZnjYhk-1738433120331-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - "<CF_RAY>"
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |
+        {
+          "id": "chatcmpl-AwC9nXhvJ9q9ag9rKI4ldAU7uqHHh",
+          "object": "chat.completion",
+          "created": 1738433119,
+          "model": "gpt-4o-mini-2024-07-18",
+          "choices": [
+            {
+              "index": 0,
+              "message": {
+                "role": "assistant",
+                "content": "Hello! How can I assist you today?",
+                "refusal": null
+              },
+              "logprobs": null,
+              "finish_reason": "stop"
+            }
+          ],
+          "usage": {
+            "prompt_tokens": 17,
+            "completion_tokens": 10,
+            "total_tokens": 27,
+            "prompt_tokens_details": {
+              "cached_tokens": 0,
+              "audio_tokens": 0
+            },
+            "completion_tokens_details": {
+              "reasoning_tokens": 0,
+              "audio_tokens": 0,
+              "accepted_prediction_tokens": 0,
+              "rejected_prediction_tokens": 0
+            }
+          },
+          "service_tier": "default",
+          "system_fingerprint": "fp_72ed7ab54c"
+        }
+  recorded_at: Sat, 01 Feb 2025 18:05:20 GMT
+recorded_with: VCR 6.3.1

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ VCR.configure do |config|
   # Filter sensitive data
   config.filter_sensitive_data("<OPENAI_API_KEY>") { ENV["OPENAI_API_KEY"] }
   config.filter_sensitive_data("<OPENAI_ORG_ID>") { ENV["OPENAI_ORG_ID"] }
-  
+
   # Filter organization IDs
   config.filter_sensitive_data("<OPENAI_ORG>") do |interaction|
     interaction.response.headers["Openai-Organization"]&.first
@@ -40,7 +40,7 @@ VCR.configure do |config|
 
   # Allow VCR to record new episodes when cassettes don't exist
   config.default_cassette_options = {
-    record: :new_episodes,
+    record: :none,
     match_requests_on: [:method, :uri],
     allow_playback_repeats: true
   }
@@ -48,6 +48,17 @@ VCR.configure do |config|
   # Don't raise errors when cassettes don't exist
   config.allow_http_connections_when_no_cassette = true
 end
+
+# Configure WebMock to disallow real network connections
+WebMock.disable_net_connect!(
+  allow_localhost: true,
+  message: "Real HTTP connections are disabled in tests. Use VCR to mock this request:\n" \
+          "describe 'your test', :vcr do\n" \
+          "  it 'does something' do\n" \
+          "    # your test code\n" \
+          "  end\n" \
+          "end"
+)
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -73,4 +84,8 @@ RSpec.configure do |config|
       example.run
     end
   end
+end
+
+Bristow.configure do |config|
+  config.logger = Logger.new(File::NULL)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,8 +45,8 @@ VCR.configure do |config|
     allow_playback_repeats: true
   }
 
-  # Don't raise errors when cassettes don't exist
-  config.allow_http_connections_when_no_cassette = true
+  # Never allow real HTTP connections
+  config.allow_http_connections_when_no_cassette = false
 end
 
 # Configure WebMock to disallow real network connections


### PR DESCRIPTION
Refactors the API to be inheritance based. The goal here is to make it work more like other rails libraries. The idea is that you'll build up some set of function, agents and agencies with a folder structure like:

```
app/
  functions/
    my_function.rb
  agents/
    my_agent.rb
    my_other_agent.rb
  agencies/
    my_agency.rb
```

And each would be implemented something like:

```ruby
# app/functions/my_function.rb
class MyFunction < Function
  name "my_function"
  description "This is my function"

  def perform
    # do something
  end
end

# app/agents/my_agent.rb
class MyAgent < Agent
  name "my_agent"
  description "This is my agent"
  functions [MyFunction]
end
```

After building out a library of functions, you'll be able to mix and match them and use them across agents. Similarly, you'll be able to do the same with agents and agencies.

closes #5
