### PR TITLE
Add workflow agency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Update the README to make it flow a bit better.
 - Add .chat to Agent
 - Give functions a default name that is the name of the class
+- Add the workflow agency
 
 ## [0.3.1] - 2025-02-01
 

--- a/README.md
+++ b/README.md
@@ -240,9 +240,9 @@ end
 campaign = SterlingCooper.new.chat("Please come up with an ad campaign for the Bristow gem")
 ```
 
-# Pre-packaged agencies
+## Pre-packaged agencies
 
-## Supervisor Agency Overview
+### Supervisor Agency Overview
 
 The supervisor agency implements a pattern something like [LangChain's Multi-agent supervisor pattern](https://langchain-ai.github.io/langgraph/tutorials/multi_agent/agent_supervisor/). You provide an array of agents, and a pre-packaged Supervisor agent will handle:
 
@@ -255,6 +255,16 @@ The supervisor agency implements a pattern something like [LangChain's Multi-age
 This can be useful when building a chat bot for your application. You can build out the agents and functions that interact with different parts of your system, a reporting agent, a user management agent, etc. You then throw them all together in in a supervisor agency, and expose a chat UI for admins. This chat UI would then be allow the AI model to interact with your application.
 
 You can see `examples/basic_agency.rb` for example code.
+
+### Worfkflow Agency Overview
+
+The workflow agency is a simple pattern that allows you to define a set of steps that should be repeated every time a user interacts with the agency. This can be useful when you have a specific set of steps that should be repeated every time a user interacts with the agency. It will:
+
+1. Receive the task from the user
+2. Call each agent in order
+3. Stream the response from the last agent in the series
+
+You can see `examples/workflow_agency.rb` for example code.
 
 ## Examples
 

--- a/examples/workflow_agency.rb
+++ b/examples/workflow_agency.rb
@@ -1,0 +1,27 @@
+require_relative '../lib/bristow'
+
+class TravelAgent < Bristow::Agent
+  name "TravelAgent"
+  description "Agent for planning trips"
+  system_message 'Given a destination, you will plan a trip. You will respond with an itinerary that includes dates, times, and locations only.'
+end
+
+class StoryTeller < Bristow::Agent
+  name "StoryTeller"
+  description 'An agent that tells a story given an agenda'
+  system_message "Given a trip agenda, you will tell a story about a traveler who recently took that trip. Be sure to highlight the traveler's experiences and emotions."
+end
+
+# The workflow agent implements basic workflow. It will call each agent in the
+# order they are listed, passing the message history to each agent. The response
+# from the last agent is streamed to the block passed to chat, but the entire
+# message history is returned.
+workflow = Bristow::Agencies::Workflow.new(agents: [TravelAgent, StoryTeller])
+
+messages = workflow.chat('New York') do |part|
+  print part
+end
+
+puts '*' * 80
+puts 'Chat history:'
+pp messages

--- a/lib/bristow.rb
+++ b/lib/bristow.rb
@@ -13,6 +13,7 @@ require_relative "bristow/agent"
 require_relative "bristow/agents/supervisor"
 require_relative "bristow/agency"
 require_relative "bristow/agencies/supervisor"
+require_relative "bristow/agencies/workflow"
 
 module Bristow
   class Error < StandardError; end

--- a/lib/bristow/agencies/workflow.rb
+++ b/lib/bristow/agencies/workflow.rb
@@ -1,0 +1,16 @@
+module Bristow
+  module Agencies
+    class Workflow < Agency
+      def chat(messages, &block)
+        return messages if agents.empty?
+
+        agents.each.with_index(1) do |agent, index|
+          last = index == agents.size
+          messages = agent.chat(messages, &(last ? block : nil))
+        end
+
+        messages
+      end
+    end
+  end
+end

--- a/spec/bristow/agencies/workflow_spec.rb
+++ b/spec/bristow/agencies/workflow_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Agencies::Workflow do
+  let(:test_agent_one) do
+    Class.new(Bristow::Agent) do
+      name "TestAgentOne"
+      description "A test agent that modifies messages"
+      system_message "You are test agent one"
+
+      def self.chat(messages, &block)
+        messages + [{ role: "assistant", content: "Agent One Response" }]
+      end
+    end
+  end
+
+  let(:test_agent_two) do
+    Class.new(Bristow::Agent) do
+      name "TestAgentTwo"
+      description "A test agent that processes messages"
+      system_message "You are test agent two"
+
+      def self.chat(messages, &block)
+        yield "Agent Two Response" if block
+        messages + [{ role: "assistant", content: "Agent Two Response" }]
+      end
+    end
+  end
+
+  let(:test_workflow) do
+    agent_one = test_agent_one
+    agent_two = test_agent_two
+    Class.new(described_class) do
+      agents [agent_one, agent_two]
+    end
+  end
+
+  subject(:workflow) { test_workflow.new }
+
+  describe "#chat" do
+    let(:messages) { [{ role: "user", content: "Hello" }] }
+    let(:block) { proc { |part| @streamed_parts << part } }
+
+    before do
+      @streamed_parts = []
+    end
+
+    it "returns original messages if no agents" do
+      workflow = described_class.new(agents: [])
+      expect(workflow.chat(messages)).to eq(messages)
+    end
+
+    it "processes messages through all agents in sequence" do
+      result = workflow.chat(messages, &block)
+      expect(result).to eq([
+        { role: "user", content: "Hello" },
+        { role: "assistant", content: "Agent One Response" },
+        { role: "assistant", content: "Agent Two Response" }
+      ])
+    end
+
+    it "only streams output from the last agent" do
+      workflow.chat(messages, &block)
+      expect(@streamed_parts).to eq(["Agent Two Response"])
+    end
+
+    it "accepts a string message" do
+      result = workflow.chat([{role: 'user', content: "Hello"}], &block)
+      expect(result.first).to eq({ role: "user", content: "Hello" })
+    end
+
+    it "works without a block" do
+      expect {
+        workflow.chat(messages)
+      }.not_to raise_error
+    end
+
+    context "with multiple agents" do
+      let(:test_workflow_three) do
+        agent_one = test_agent_one
+        agent_two = test_agent_two
+        agent_three = Class.new(test_agent_two) do
+          name "TestAgentThree"
+          def self.chat(messages, &block)
+            yield "Agent Three Response" if block
+            messages + [{ role: "assistant", content: "Agent Three Response" }]
+          end
+        end
+
+        Class.new(described_class) do
+          agents [agent_one, agent_two, agent_three]
+        end
+      end
+
+      it "processes through all agents and only streams the last one" do
+        workflow = test_workflow_three.new
+        workflow.chat(messages, &block)
+        expect(@streamed_parts).to eq(["Agent Three Response"])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds the workflow agency. The workflow agency is given an array of agents. In each chat, it will loop through each of the provided agents in order, calling each one. The final agent will have it's response streamed via the block passed to `#chat`.

closes #2
