### PR TITLE
Fix `name` -> `*_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add termination conditions so you can ensure an agent stop after a certain amount of time.
 - Drop VCR in favor of WebMock for testing
+- Fix `name` shadowing the built-in function for agent and function
 
 ## [0.4.0] - 2025-02-15
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ end
 # Define functions that the model can call to interact with your app
 class UserSearch < Bristow::Function
   # Name that will be provided to the AI model for function calls
-  name "user_search"
+  function_name "user_search"
 
   # Description for the AI model that it can use to determine when
   # it should call this function
@@ -76,7 +76,7 @@ end
 
 # Create an agent with access to the function
 class UserQueryAssistant < Bristow::Agent
-  name "UserQueryAssistant"
+  agent_name "UserQueryAssistant"
   description "Helps with user-related queries"
   system_message <<~MSG 
     You are a user management assistant. 
@@ -126,7 +126,7 @@ Agents can be configured similar to something like `ActiveJob` or `Sidekiq`. You
 
 ```ruby
 class Pirate < Bristow::Agent
-  name "Pirate"
+  agent_name "Pirate"
   description "An agent that assists the user while always talking like a pirate."
   system_message "You are a helpful assistant that always talks like a pirate. Try to be as corny and punny as possible."
 end
@@ -141,7 +141,7 @@ end
 
 Here's an overview of all config options available when configuring an Agent:
 
-- `name`: The name of the agent
+- `agent_name`: The name of the agent
 - `description`: Description of what the agent can do. Can be used by agencies to provide information about the agent, informing the model when this agent should be used.
 - `system_message`: The system message to be sent before the first user message. This can be used to provide context to the model about the conversation.
 - `functions`: An array of `Bristow::Function` classes that the agent has access to. When working on the task assigned by the user, the AI model will have access to these functions, and will decide when a call to any function call is necessary.
@@ -168,7 +168,7 @@ You can think of functions as an API for your application for the AI model. When
 
 ```ruby
 class TodoAssigner < Bristow::Function
-  name "todo_assigner"
+  function_name "todo_assigner"
   description "Given a user ID and a todo ID, it will assign the todo to the user."
   parameters({
     properties: {
@@ -198,7 +198,7 @@ end
 
 Functions have 3 config options, and a `#perform` function:
 
-- `name`: The name of the function. Provided to the AI model to help it call this function, and can be used to determine whether or not this function should be called.
+- `function_name`: The name of the function. Provided to the AI model to help it call this function, and can be used to determine whether or not this function should be called.
 - `description`: A description of the function that will be provided to the AI model. Important for informing the model about what this function can do, so it's able to determine when to call this function.
 - `parameters`: The JSON schema definition of the function's API. See Open AI's [function docs](https://platform.openai.com/docs/guides/function-calling) for detailed information.
 - `#perform`: The perform function is your implementation for the function. You'll check out the parameters passed in from the model, and handle any operation it's requesting to do.
@@ -288,7 +288,7 @@ end
 
 # You can overrided these settings on a per-agent basis like this:
 storyteller = Bristow::Agent.new(
-  name: 'Sydney',
+  agent_name: 'Sydney',
   description: 'Agent for telling spy stories',
   system_message: 'Given a topic, you will tell a brief spy story',
   model: 'gpt-4o-mini',

--- a/examples/basic_agency.rb
+++ b/examples/basic_agency.rb
@@ -1,13 +1,13 @@
 require_relative '../lib/bristow'
 
 class PirateTalker < Bristow::Agent
-  name "PirateSpeaker"
+  agent_name "PirateSpeaker"
   description "Agent for translating input to pirate-speak"
   system_message 'Given a text, you will translate it to pirate-speak.'
 end
 
 class TravelAgent < Bristow::Agent
-  name "TravelAgent"
+  agent_name "TravelAgent"
   description "Agent for planning trips"
   system_message 'Given a destination, you will plan a trip. You will respond with an itinerary that includes dates, times, and locations only.'
 end

--- a/examples/basic_agent.rb
+++ b/examples/basic_agent.rb
@@ -5,7 +5,7 @@ Bristow.configure do |config|
 end
 
 class Sydney < Bristow::Agent
-  name 'Sydney'
+  agent_name 'Sydney'
   description 'Agent for telling spy stories'
   system_message 'Given a topic, you will tell a brief spy story'
 end

--- a/examples/basic_termination.rb
+++ b/examples/basic_termination.rb
@@ -1,7 +1,7 @@
 require_relative '../lib/bristow'
 
 class CountAgent < Bristow::Agent
-  name "CounterAgent"
+  agent_name "CounterAgent"
   description "Knows how to count"
   system_message "You are a helpful mupet vampire that knows how to count very well. You will find the last message in the series and reply with the next integer."
   termination Bristow::Terminations::MaxMessages.new(3)

--- a/examples/function_calls.rb
+++ b/examples/function_calls.rb
@@ -6,7 +6,7 @@ end
 
 # Define functions that GPT can call
 class WeatherLookup < Bristow::Function
-  name "get_weather"
+  function_name "get_weather"
   description "Get the current weather for a location"
   parameters ({
     type: "object",
@@ -32,7 +32,7 @@ end
 
 # Create an agent with these functions
 class WeatherAgent < Bristow::Agent
-  name "WeatherAssistant"
+  agent_name "WeatherAssistant"
   description "Helps with weather-related queries"
   system_message "You are a helpful weather assistant. You'll be asked about the weather, and should use the get_weather function to respond."
   functions [WeatherLookup]

--- a/examples/workflow_agency.rb
+++ b/examples/workflow_agency.rb
@@ -1,13 +1,13 @@
 require_relative '../lib/bristow'
 
 class TravelAgent < Bristow::Agent
-  name "TravelAgent"
+  agent_name "TravelAgent"
   description "Agent for planning trips"
   system_message 'Given a destination, you will plan a trip. You will respond with an itinerary that includes dates, times, and locations only.'
 end
 
 class StoryTeller < Bristow::Agent
-  name "StoryTeller"
+  agent_name "StoryTeller"
   description 'An agent that tells a story given an agenda'
   system_message "Given a trip agenda, you will tell a story about a traveler who recently took that trip. Be sure to highlight the traveler's experiences and emotions."
 end

--- a/lib/bristow/agency.rb
+++ b/lib/bristow/agency.rb
@@ -17,7 +17,7 @@ module Bristow
     end
 
     def find_agent(name)
-      agent = agents.find { |agent| agent_name(agent) == name }
+      agent = agents.find { |agent| agent_name_for(agent) == name }
       return nil unless agent
       
       agent.is_a?(Class) ? agent.new : agent
@@ -32,8 +32,8 @@ module Bristow
 
     private
 
-    def agent_name(agent)
-      agent.is_a?(Class) ? agent.name : agent.class.name
+    def agent_name_for(agent)
+      agent.is_a?(Class) ? agent.agent_name : agent.class.agent_name
     end
   end
 end

--- a/lib/bristow/agent.rb
+++ b/lib/bristow/agent.rb
@@ -2,7 +2,7 @@ module Bristow
   class Agent
     include Bristow::Sgetter
 
-    sgetter :name
+    sgetter :agent_name
     sgetter :description
     sgetter :system_message
     sgetter :functions, default: []
@@ -11,10 +11,12 @@ module Bristow
     sgetter :logger, default: -> { Bristow.configuration.logger }
     sgetter :termination, default: -> { Bristow::Terminations::MaxMessages.new(100) }
     attr_reader :chat_history
+    
+
 
     def initialize(
-      name: self.class.name,
-      description: self.class.name,
+      agent_name: self.class.agent_name,
+      description: self.class.description,
       system_message: self.class.system_message,
       functions: self.class.functions.dup,
       model: self.class.model,
@@ -22,7 +24,7 @@ module Bristow
       logger: self.class.logger,
       termination: self.class.termination
     )
-      @name = name
+      @agent_name = agent_name
       @description = description
       @system_message = system_message
       @functions = functions
@@ -34,7 +36,7 @@ module Bristow
     end
 
     def handle_function_call(name, arguments)
-      function = functions.find { |f| f.name == name }
+      function = functions.find { |f| f.function_name == name }
       raise ArgumentError, "Function #{name} not found" unless function
       function.call(**arguments.transform_keys(&:to_sym))
     end

--- a/lib/bristow/agents/supervisor.rb
+++ b/lib/bristow/agents/supervisor.rb
@@ -5,7 +5,7 @@ module Bristow
     class Supervisor < Agent
       attr_reader :agency
 
-      name "Supervisor"
+      agent_name "Supervisor"
       description "A supervisor agent that coordinates between specialized agents"
       system_message <<~MESSAGE
         You are a supervisor agent that coordinates between specialized agents.
@@ -32,14 +32,15 @@ module Bristow
         @custom_instructions = custom_instructions || self.class.custom_instructions
         @termination = termination
         agency.agents << self
-        functions << Functions::Delegate.new(self, agency)
+        @functions ||= []
+        @functions << Functions::Delegate.new(self, agency)
       end
 
       private
 
       def build_system_message(available_agents)
         agent_descriptions = available_agents.map do |agent|
-          "- #{agent.name}: #{agent.description}"
+          "- #{agent.agent_name}: #{agent.description}"
         end.join("\n")
 
         <<~MESSAGE

--- a/lib/bristow/function.rb
+++ b/lib/bristow/function.rb
@@ -5,13 +5,23 @@ module Bristow
     include Bristow::Sgetter
     include Bristow::Delegate
 
-    sgetter :name, default: -> { self.class.name }
+    sgetter :function_name, default: nil
     sgetter :description
     sgetter :parameters, default: {}
 
+    def initialize(
+      function_name: self.class.function_name,
+      description: self.class.description,
+      parameters: self.class.parameters
+    )
+      @function_name = function_name
+      @description = description
+      @parameters = parameters
+    end
+
     def self.to_openai_schema
       {
-        name: name,
+        name: function_name,
         description: description,
         parameters: parameters
       }

--- a/lib/bristow/functions/delegate.rb
+++ b/lib/bristow/functions/delegate.rb
@@ -3,9 +3,7 @@
 module Bristow
   module Functions
     class Delegate < Function
-      def self.name
-        "delegate_to"
-      end
+      function_name "delegate_to"
 
       def self.description
         "Delegate a task to a specialized agent"
@@ -28,10 +26,6 @@ module Bristow
         }
       end
 
-      def name
-        self.class.name
-      end
-
       def description
         self.class.description
       end
@@ -45,6 +39,7 @@ module Bristow
 
         @agent = agent
         @agency = agency
+        super()
       end
 
       def agency=(agency)
@@ -54,7 +49,7 @@ module Bristow
       def perform(agent_name:, message:)
         raise "Agency not set" if @agency.nil?
 
-        if agent_name == @agent.name
+        if agent_name == @agent.agent_name
           { error: "Cannot delegate to self" }
         else
           agent = @agency.find_agent(agent_name)

--- a/lib/bristow/helpers/sgetter.rb
+++ b/lib/bristow/helpers/sgetter.rb
@@ -4,16 +4,16 @@
 # Example:
 # class Agent
 #   include Bristow::Sgetter
-#   sgetter :name
+#   sgetter :agent_name
 #   sgetter :model, default: -> { Bristow.configuration.model }
 # end
 #
 # class Sydney < Agent
-#   name 'Sydney'
+#   agent_name 'Sydney'
 # end
 #
 # sydney = Sydney.new
-# sydney.name # => 'Sydney'
+# sydney.agent_name # => 'Sydney'
 module Bristow
   module Sgetter
     def self.included(base)

--- a/spec/bristow/agencies/supervisor_spec.rb
+++ b/spec/bristow/agencies/supervisor_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
-
 RSpec.describe Bristow::Agencies::Supervisor do
   let(:test_agent_one) do
     Class.new(Bristow::Agent) do
-      name "TestAgentOne"
+      agent_name "TestAgentOne"
       description "A test agent that modifies messages"
       system_message "You are test agent one"
     end
@@ -11,7 +10,7 @@ RSpec.describe Bristow::Agencies::Supervisor do
 
   let(:test_agent_two) do
     Class.new(Bristow::Agent) do
-      name "TestAgentTwo"
+      agent_name "TestAgentTwo"
       description "A test agent that processes messages"
       system_message "You are test agent two"
     end
@@ -58,7 +57,7 @@ RSpec.describe Bristow::Agencies::Supervisor do
   end
   before(:all) do
     @test_function = Class.new(Bristow::Function) do
-      name "test_function"
+      function_name "test_function"
       description "A test function"
       parameters({
         type: "object",
@@ -77,7 +76,7 @@ RSpec.describe Bristow::Agencies::Supervisor do
     end
 
     @test_agent_class = Class.new(Bristow::Agent) do
-      name "TestAgent"
+      agent_name "TestAgent"
       description "A test agent"
       system_message "You are a test agent"
       functions [@test_function]
@@ -143,7 +142,7 @@ RSpec.describe Bristow::Agencies::Supervisor do
   end
 
   describe "delegation" do
-    let(:delegate_fn) { agency.supervisor.functions.find { |f| f.name == "delegate_to" } }
+    let(:delegate_fn) { agency.supervisor.functions.find { |f| f.function_name == "delegate_to" } }
 
     it "delegates to the specified agent" do
       stub_request(:post, "https://api.openai.com/v1/chat/completions")

--- a/spec/bristow/agencies/workflow_spec.rb
+++ b/spec/bristow/agencies/workflow_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Bristow::Agencies::Workflow do
   let(:test_agent_one) do
     Class.new(Bristow::Agent) do
-      name "TestAgentOne"
+      agent_name "TestAgentOne"
       description "A test agent that modifies messages"
       system_message "You are test agent one"
 
@@ -15,7 +15,7 @@ RSpec.describe Bristow::Agencies::Workflow do
 
   let(:test_agent_two) do
     Class.new(Bristow::Agent) do
-      name "TestAgentTwo"
+      agent_name "TestAgentTwo"
       description "A test agent that processes messages"
       system_message "You are test agent two"
 
@@ -121,7 +121,7 @@ RSpec.describe Bristow::Agencies::Workflow do
         agent_one = test_agent_one
         agent_two = test_agent_two
         agent_three = Class.new(test_agent_two) do
-          name "TestAgentThree"
+          agent_name "TestAgentThree"
           def self.chat(messages, &block)
             yield "Agent Three Response" if block
             messages + [{ role: "assistant", content: "Agent Three Response" }]

--- a/spec/bristow/agency_spec.rb
+++ b/spec/bristow/agency_spec.rb
@@ -3,12 +3,12 @@
 RSpec.describe Bristow::Agency do
   before(:all) do
     @test_agent1_class = Class.new(Bristow::Agent) do
-      name "TestAgent1"
+      agent_name "TestAgent1"
       description "A test agent"
     end
 
     @test_agent2_class = Class.new(Bristow::Agent) do
-      name "TestAgent2"
+      agent_name "TestAgent2"
       description "Another test agent"
     end
   end
@@ -40,11 +40,11 @@ RSpec.describe Bristow::Agency do
   end
 
   describe "#find_agent" do
-    it "finds an agent by name from a class" do
+    it "finds an agent by agent_name from a class" do
       expect(agency.find_agent("TestAgent1")).to be_a(@test_agent1_class)
     end
 
-    it "finds an agent by name from an instance" do
+    it "finds an agent by agent_name from an instance" do
       expect(agency.find_agent("TestAgent1")).to be_a(@test_agent1_class)
     end
 

--- a/spec/bristow/agent_spec.rb
+++ b/spec/bristow/agent_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Bristow::Agent do
   before(:all) do
     @test_function = Class.new(Bristow::Function) do
-      name "test_function"
+      function_name "test_function"
       description "A test function"
       parameters({
         type: "object",
@@ -25,7 +25,7 @@ RSpec.describe Bristow::Agent do
   let(:test_agent) do
     test_function = @test_function
     Class.new(described_class) do
-      name "TestAgent"
+      agent_name "TestAgent"
       description "A test agent"
       system_message "You are a test agent that helps with testing. When asked to test something, always use the test_function."
       model "gpt-3.5-turbo"
@@ -35,9 +35,9 @@ RSpec.describe Bristow::Agent do
 
   subject(:agent) { test_agent.new }
 
-  describe ".name" do
+  describe ".agent_name" do
     it "sets and gets the agent name" do
-      expect(test_agent.name).to eq("TestAgent")
+      expect(test_agent.agent_name).to eq("TestAgent")
     end
   end
 
@@ -60,7 +60,7 @@ RSpec.describe Bristow::Agent do
 
     it "defaults to configuration default model" do
       agent_class = Class.new(described_class) do
-        name "DefaultModelAgent"
+        agent_name "DefaultModelAgent"
       end
       expect(agent_class.model).to eq(Bristow.configuration.model)
     end
@@ -73,7 +73,7 @@ RSpec.describe Bristow::Agent do
 
     it "defaults to empty array" do
       agent_class = Class.new(described_class) do
-        name "NoFunctionsAgent"
+        agent_name "NoFunctionsAgent"
       end
       expect(agent_class.functions).to eq([])
     end

--- a/spec/bristow/agents/supervisor_spec.rb
+++ b/spec/bristow/agents/supervisor_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
-
 RSpec.describe Bristow::Agents::Supervisor do
   before(:all) do
     @test_agent_class = Class.new(Bristow::Agent) do
-      name "TestAgent"
+      agent_name "TestAgent"
       description "A test agent"
       system_message "You are a test agent"
     end
@@ -22,7 +21,7 @@ RSpec.describe Bristow::Agents::Supervisor do
 
   describe ".class_methods" do
     it "has correct class-level attributes" do
-      expect(described_class.name).to eq("Supervisor")
+      expect(described_class.agent_name).to eq("Supervisor")
       expect(described_class.description).to eq("A supervisor agent that coordinates between specialized agents")
       expect(described_class.custom_instructions).to be_nil
     end
@@ -37,12 +36,12 @@ RSpec.describe Bristow::Agents::Supervisor do
 
   describe "#initialize" do
     it "creates a supervisor with available agents" do
-      expect(supervisor.name).to eq("Supervisor")
+      expect(supervisor.agent_name).to eq("Supervisor")
       expect(described_class.description).to eq("A supervisor agent that coordinates between specialized agents")
     end
 
     it "includes agent descriptions in system message" do
-      expect(supervisor.system_message).to match(/Available agents:\n- TestAgent: TestAgent\n/)
+      expect(supervisor.system_message).to match(/Available agents:\n- TestAgent: A test agent\n/)
     end
 
     it "includes custom instructions in system message" do
@@ -59,7 +58,7 @@ RSpec.describe Bristow::Agents::Supervisor do
 
     it "sets up delegation function" do
       delegate_fn = supervisor.functions.first
-      expect(delegate_fn.name).to eq("delegate_to")
+      expect(delegate_fn.function_name).to eq("delegate_to")
       expect(delegate_fn.parameters[:properties]).to include(:agent_name, :message)
     end
 
@@ -213,7 +212,7 @@ RSpec.describe Bristow::Agents::Supervisor do
 
     it "has correct class-level attributes" do
       delegate_class = Bristow::Functions::Delegate
-      expect(delegate_class.name).to eq("delegate_to")
+      expect(delegate_class.function_name).to eq("delegate_to")
       expect(delegate_class.description).to eq("Delegate a task to a specialized agent")
       expect(delegate_class.parameters).to include(
         type: "object",
@@ -227,7 +226,7 @@ RSpec.describe Bristow::Agents::Supervisor do
 
     it "delegates class methods to instance methods" do
       delegate = Bristow::Functions::Delegate.new(supervisor, agency)
-      expect(delegate.name).to eq(Bristow::Functions::Delegate.name)
+      expect(delegate.function_name).to eq(Bristow::Functions::Delegate.function_name)
       expect(delegate.description).to eq(Bristow::Functions::Delegate.description)
       expect(delegate.parameters).to eq(Bristow::Functions::Delegate.parameters)
     end

--- a/spec/bristow/function_spec.rb
+++ b/spec/bristow/function_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe Bristow::Function do
   let(:test_function_class) do
     Class.new(described_class) do
-      name "test_function"
+      function_name "test_function"
       description "A test function"
       parameters({
         properties: {
@@ -31,9 +31,9 @@ RSpec.describe Bristow::Function do
 
   subject(:function) { test_function_class.new }
 
-  describe ".name" do
+  describe ".function_name" do
     it "sets and gets the function name" do
-      expect(test_function_class.name).to eq("test_function")
+      expect(test_function_class.function_name).to eq("test_function")
     end
   end
 

--- a/spec/bristow/functions/delegate_spec.rb
+++ b/spec/bristow/functions/delegate_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 RSpec.describe Bristow::Functions::Delegate do
   let(:test_agent) do
     Class.new(Bristow::Agent) do
-      name "TestAgent"
+      agent_name "TestAgent"
       description "A test agent"
       system_message "You are a test agent"
     end.new
@@ -67,8 +67,8 @@ RSpec.describe Bristow::Functions::Delegate do
   end
 
   describe "class methods" do
-    it "has correct name" do
-      expect(described_class.name).to eq("delegate_to")
+    it "has correct function_name" do
+      expect(described_class.function_name).to eq("delegate_to")
     end
 
     it "has description" do


### PR DESCRIPTION
This is so we don't override the built in .name for the Ruby classes.
