### PR TITLE
Add Anthropic support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,16 @@ jobs:
       OPENAI_API_KEY: dummy-key-for-tests
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ["3.2", "3.3", "3.4"]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby ${{ matrix.ruby-version }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true
-    - name: Install dependencies
-      run: bundle install
-    - name: Run tests
-      run: bundle exec rspec
+      - uses: actions/checkout@v4
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Drop support for ruby 3.0 and 3.1
+- Add Anthropic API support
+
 ## [0.5.1] - 2025-05-08
 
 - Improve publish script

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     bristow (0.5.1)
+      anthropic (~> 1.0)
       ruby-openai (~> 7.0.0)
 
 GEM
@@ -9,7 +10,10 @@ GEM
   specs:
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    anthropic (1.1.0)
+      connection_pool
     bigdecimal (3.1.9)
+    connection_pool (2.5.3)
     crack (1.0.0)
       bigdecimal
       rexml

--- a/bristow.gemspec
+++ b/bristow.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "ruby-openai", "~> 7.0.0"
+  spec.add_dependency "anthropic", "~> 1.0"
 
   spec.add_development_dependency "debug", "~> 1.10"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,33 @@
+# Bristow Examples
+
+This directory contains examples demonstrating various features of Bristow.
+
+## Provider Selection
+
+All examples support provider selection via the `BRISTOW_PROVIDER` environment variable:
+
+### OpenAI (default)
+```bash
+ruby basic_agent.rb
+# or explicitly
+BRISTOW_PROVIDER=openai ruby basic_agent.rb
+```
+
+### Anthropic (Claude)
+```bash
+BRISTOW_PROVIDER=anthropic ruby basic_agent.rb
+```
+
+Make sure to set the appropriate API key:
+- `OPENAI_API_KEY` for OpenAI
+- `ANTHROPIC_API_KEY` for Anthropic
+
+## Examples
+
+- **basic_agent.rb** - Simple agent that tells spy stories
+- **function_calls.rb** - Agent with function calling capabilities (weather lookup)
+- **basic_agency.rb** - Multi-agent system with supervisor coordination
+- **basic_termination.rb** - Agent with conversation termination conditions
+- **workflow_agency.rb** - Sequential workflow between agents
+
+All examples work identically across providers thanks to Bristow's universal function schema format.

--- a/examples/basic_agency.rb
+++ b/examples/basic_agency.rb
@@ -1,5 +1,18 @@
 require_relative '../lib/bristow'
 
+Bristow.configure do |config|
+  # Set provider based on environment variable, default to OpenAI
+  provider = ENV['BRISTOW_PROVIDER']&.to_sym || :openai
+  config.default_provider = provider
+
+  case provider
+  when :anthropic
+    config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+  when :openai
+    config.model = 'gpt-4o-mini'
+  end
+end
+
 class PirateTalker < Bristow::Agent
   agent_name "PirateSpeaker"
   description "Agent for translating input to pirate-speak"

--- a/examples/basic_agent.rb
+++ b/examples/basic_agent.rb
@@ -1,7 +1,16 @@
 require_relative '../lib/bristow'
 
 Bristow.configure do |config|
+  # Set provider based on environment variable, default to OpenAI
+  provider = ENV['BRISTOW_PROVIDER']&.to_sym || :openai
+  config.default_provider = provider
+
+  case provider
+  when :anthropic
+    config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+  when :openai
     config.model = 'gpt-4o-mini'
+  end
 end
 
 class Sydney < Bristow::Agent

--- a/examples/basic_termination.rb
+++ b/examples/basic_termination.rb
@@ -1,5 +1,18 @@
 require_relative '../lib/bristow'
 
+Bristow.configure do |config|
+  # Set provider based on environment variable, default to OpenAI
+  provider = ENV['BRISTOW_PROVIDER']&.to_sym || :openai
+  config.default_provider = provider
+
+  case provider
+  when :anthropic
+    config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+  when :openai
+    config.model = 'gpt-4o-mini'
+  end
+end
+
 class CountAgent < Bristow::Agent
   agent_name "CounterAgent"
   description "Knows how to count"

--- a/examples/function_calls.rb
+++ b/examples/function_calls.rb
@@ -1,7 +1,16 @@
 require_relative '../lib/bristow'
 
 Bristow.configure do |config|
+  # Set provider based on environment variable, default to OpenAI
+  provider = ENV['BRISTOW_PROVIDER']&.to_sym || :openai
+  config.default_provider = provider
+
+  case provider
+  when :anthropic
+    config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+  when :openai
     config.model = 'gpt-4o-mini'
+  end
 end
 
 # Define functions that GPT can call
@@ -39,7 +48,7 @@ class WeatherAgent < Bristow::Agent
 end
 
 # Start a conversation
-messages = WeatherAgent.chat("What's the weather like in London?") do |part|
+messages = WeatherAgent.chat("What's the weather like in London, UK?") do |part|
   print part
 end
 

--- a/examples/workflow_agency.rb
+++ b/examples/workflow_agency.rb
@@ -1,5 +1,18 @@
 require_relative '../lib/bristow'
 
+Bristow.configure do |config|
+  # Set provider based on environment variable, default to OpenAI
+  provider = ENV['BRISTOW_PROVIDER']&.to_sym || :openai
+  config.default_provider = provider
+
+  case provider
+  when :anthropic
+    config.anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+  when :openai
+    config.model = 'gpt-4o-mini'
+  end
+end
+
 class TravelAgent < Bristow::Agent
   agent_name "TravelAgent"
   description "Agent for planning trips"

--- a/lib/bristow.rb
+++ b/lib/bristow.rb
@@ -1,11 +1,16 @@
 # frozen_string_literal: true
 require 'openai'
+require 'anthropic'
 require 'logger'
 require 'json'
 
 require_relative "bristow/version"
 require_relative "bristow/helpers/sgetter"
 require_relative "bristow/helpers/delegate"
+require_relative "bristow/providers/base"
+require_relative "bristow/providers/openai"
+require_relative "bristow/providers/anthropic"
+require_relative "bristow/providers/google"
 require_relative "bristow/configuration"
 require_relative "bristow/function"
 require_relative "bristow/functions/delegate"

--- a/lib/bristow/configuration.rb
+++ b/lib/bristow/configuration.rb
@@ -1,24 +1,72 @@
 module Bristow
   class Configuration
-    attr_accessor :openai_api_key, :model, :logger
-    attr_reader :client
+    attr_accessor :openai_api_key, :anthropic_api_key, :google_api_key, 
+                  :default_provider, :default_model, :logger
+    attr_reader :clients
 
     def initialize
       @openai_api_key = ENV['OPENAI_API_KEY']
-      @model = 'gpt-4o-mini'
+      @anthropic_api_key = ENV['ANTHROPIC_API_KEY']
+      @google_api_key = ENV['GOOGLE_API_KEY']
+      @default_provider = :openai
+      @default_model = nil  # Will use provider's default
       @logger = Logger.new(STDOUT)
-      reset_client
+      @clients = {}
     end
 
     def openai_api_key=(key)
       @openai_api_key = key
-      reset_client
+      reset_client(:openai)
+    end
+
+    def anthropic_api_key=(key)
+      @anthropic_api_key = key
+      reset_client(:anthropic)
+    end
+
+    def google_api_key=(key)
+      @google_api_key = key
+      reset_client(:google)
+    end
+
+    def client_for(provider)
+      @clients[provider] ||= build_client_for(provider)
+    end
+
+    # Backward compatibility
+    def client
+      client_for(default_provider)
+    end
+
+    # Backward compatibility  
+    def model
+      @default_model || client_for(default_provider).default_model
+    end
+
+    def model=(model)
+      @default_model = model
     end
 
     private
 
-    def reset_client
-      @client = OpenAI::Client.new(access_token: @openai_api_key)
+    def build_client_for(provider)
+      case provider
+      when :openai
+        raise ArgumentError, "OpenAI API key not configured" unless @openai_api_key
+        Providers::Openai.new(api_key: @openai_api_key)
+      when :anthropic
+        raise ArgumentError, "Anthropic API key not configured" unless @anthropic_api_key
+        Providers::Anthropic.new(api_key: @anthropic_api_key)
+      when :google
+        raise ArgumentError, "Google API key not configured" unless @google_api_key
+        Providers::Google.new(api_key: @google_api_key)
+      else
+        raise ArgumentError, "Unknown provider: #{provider}"
+      end
+    end
+
+    def reset_client(provider)
+      @clients.delete(provider)
     end
   end
 

--- a/lib/bristow/function.rb
+++ b/lib/bristow/function.rb
@@ -19,14 +19,14 @@ module Bristow
       @parameters = parameters
     end
 
-    def self.to_openai_schema
+    def self.to_schema
       {
         name: function_name,
         description: description,
         parameters: parameters
       }
     end
-    delegate :to_openai_schema, to: :class
+    delegate :to_schema, to: :class
 
     def self.call(...)
       new.call(...)

--- a/lib/bristow/providers/anthropic.rb
+++ b/lib/bristow/providers/anthropic.rb
@@ -1,0 +1,184 @@
+module Bristow
+  module Providers
+    class Anthropic < Base
+      def initialize(api_key:)
+        super
+        @client = ::Anthropic::Client.new(api_key: api_key)
+      end
+
+      def chat(params)
+        # Convert messages format for Anthropic
+        anthropic_params = convert_params(params)
+
+        response = @client.messages.create(anthropic_params)
+
+        # Convert response back to standard format
+        if response.content.any? { |content| content.type == "tool_use" }
+          # Handle tool use response
+          tool_use = response.content.find { |content| content.type == "tool_use" }
+          {
+            "role" => "assistant",
+            "function_call" => {
+              "name" => tool_use.name,
+              "arguments" => tool_use.input.to_json
+            }
+          }
+        else
+          # Handle text response
+          text_content = response.content.find { |content| content.type == "text" }&.text || ""
+          {
+            "role" => "assistant",
+            "content" => text_content
+          }
+        end
+      end
+
+      def stream_chat(params, &block)
+        anthropic_params = convert_params(params)
+
+        full_content = ""
+        tool_use = {}
+        tool_use_content_json = ""
+
+        stream = @client.messages.stream_raw(anthropic_params)
+        stream.each do |event|
+          case event.type
+          when :content_block_delta
+            if event.delta.type == :text_delta
+              text = event.delta.text
+              full_content += text
+              yield text if block_given?
+            elsif event.delta.type == :input_json_delta
+              # Accumulate tool input JSON fragments
+              tool_use_content_json += event.delta.partial_json || ""
+            end
+          when :content_block_start
+            if event.content_block.type == :tool_use
+              tool_use = event.content_block
+            end
+          end
+        end
+
+        if tool_use.to_hash.any?
+          {
+            "role" => "assistant",
+            content: [tool_use.to_hash.merge({input: JSON.parse(tool_use_content_json)})]
+          }
+        else
+          {
+            "role" => "assistant",
+            "content" => full_content
+          }
+        end
+      end
+
+      def format_functions(functions)
+        {
+          tools: functions.map { |func| convert_function_to_tool(func.to_schema) }
+        }
+      end
+
+      def is_function_call?(response)
+        response.dig(:content, 0, :type) == :tool_use
+      end
+
+      def function_name(response)
+        # TODO: support parallel function calls
+        response[:content][0][:name]
+      end
+
+      def function_arguments(response)
+        # TODO: support parallel function calls
+        response[:content][0][:input]
+      end
+
+      def format_function_response(response, result)
+        {
+          role: :user,
+          content: [{
+            type: "tool_result",
+            tool_use_id: response[:content][0][:id],
+            content: result.to_json
+          }]
+        }
+      end
+
+      def default_model
+        "claude-3-5-sonnet-20241022"
+      end
+
+      private
+
+      def convert_params(params)
+        # Extract system messages and regular messages
+        messages = params[:messages] || []
+        system_messages = messages.select { |msg| msg["role"] == "system" || msg[:role] == "system" }
+        other_messages = messages.reject { |msg| msg["role"] == "system" || msg[:role] == "system" }
+
+        anthropic_params = {
+          model: params[:model] || default_model,
+          max_tokens: params[:max_tokens] || 1024,
+          messages: convert_messages(other_messages)
+        }
+
+        # Add system message if present
+        if system_messages.any?
+          anthropic_params[:system] = system_messages.map { |msg| msg["content"] || msg[:content] }.join("\n")
+        end
+
+        # Add tools if present
+        if params[:tools]
+          anthropic_params[:tools] = params[:tools]
+        elsif params[:functions]
+          anthropic_params[:tools] = params[:functions].map { |func| convert_function_to_tool(func) }
+        end
+
+        anthropic_params
+      end
+
+      def convert_messages(messages)
+        messages.map do |msg|
+          role = msg["role"] || msg[:role]
+          case role
+          when "function"
+            # Convert function result to user message
+            {
+              "role" => "user",
+              "content" => "Function result: #{msg['content'] || msg[:content]}"
+            }
+          else
+            # Handle regular user/assistant messages
+            function_call = msg["function_call"] || msg[:function_call]
+            if function_call
+              # Convert function call to tool use format
+              {
+                "role" => "assistant",
+                "content" => [
+                  {
+                    "type" => "tool_use",
+                    "id" => "call_#{rand(1000000)}",
+                    "name" => function_call["name"] || function_call[:name],
+                    "input" => JSON.parse(function_call["arguments"] || function_call[:arguments])
+                  }
+                ]
+              }
+            else
+              {
+                "role" => role,
+                "content" => msg["content"] || msg[:content]
+              }
+            end
+          end
+        end
+      end
+
+      def convert_function_to_tool(func_schema)
+        {
+          "name" => func_schema[:name],
+          "description" => func_schema[:description],
+          "input_schema" => func_schema[:parameters]
+        }
+      end
+    end
+  end
+end

--- a/lib/bristow/providers/base.rb
+++ b/lib/bristow/providers/base.rb
@@ -1,0 +1,49 @@
+module Bristow
+  module Providers
+    class Base
+      attr_reader :api_key
+
+      def initialize(api_key:)
+        @api_key = api_key
+        raise ArgumentError, "API key is required" if api_key.nil? || api_key.empty?
+      end
+
+      # Abstract method - must be implemented by subclasses
+      def chat(params)
+        raise NotImplementedError, "Subclasses must implement #chat"
+      end
+
+      # Abstract method - must be implemented by subclasses
+      def stream_chat(params, &block)
+        raise NotImplementedError, "Subclasses must implement #stream_chat"
+      end
+
+      # Abstract method - must be implemented by subclasses
+      def format_functions(functions)
+        raise NotImplementedError, "Subclasses must implement #format_functions"
+      end
+
+      # Abstract method - must be implemented by subclasses
+      def default_model
+        raise NotImplementedError, "Subclasses must implement #default_model"
+      end
+
+      def is_function_call?(response)
+        raise NotImplementedError, "Subclasses must implement #is_function_call?"
+      end
+
+      def function_name(response)
+        raise NotImplementedError, "Subclasses must implement #function_name"
+      end
+
+      def function_arguments(response)
+        raise NotImplementedError, "Subclasses must implement #function_arguments"
+      end
+
+      def format_function_response(response, result)
+        raise NotImplementedError, "Subclasses must implement #format_function_response"
+      end
+
+    end
+  end
+end

--- a/lib/bristow/providers/google.rb
+++ b/lib/bristow/providers/google.rb
@@ -1,0 +1,29 @@
+module Bristow
+  module Providers
+    class Google < Base
+      def initialize(api_key:)
+        super
+        # Will implement Google client when gem is available  
+        @client = nil # Placeholder for Google::GenerativeAI::Client.new(api_key: api_key)
+      end
+
+      def chat(params)
+        raise NotImplementedError, "Google provider not yet implemented"
+      end
+
+      def stream_chat(params, &block)
+        raise NotImplementedError, "Google provider not yet implemented"
+      end
+
+      def format_functions(functions)
+        # Google uses function declarations format
+        # Will implement when Google client is added
+        raise NotImplementedError, "Google provider not yet implemented"
+      end
+
+      def default_model
+        "gemini-pro"
+      end
+    end
+  end
+end

--- a/lib/bristow/providers/openai.rb
+++ b/lib/bristow/providers/openai.rb
@@ -1,0 +1,90 @@
+module Bristow
+  module Providers
+    class Openai < Base
+      def initialize(api_key:)
+        super
+        @client = OpenAI::Client.new(access_token: api_key)
+      end
+
+      def chat(params)
+        response = @client.chat(parameters: params)
+        response.dig("choices", 0, "message")
+      end
+
+      def stream_chat(params, &block)
+        full_content = ""
+        function_name = nil
+        function_args = ""
+
+        stream_proc = proc do |chunk|
+          delta = chunk.dig("choices", 0, "delta")
+          next unless delta
+
+          if delta["function_call"]
+            # Building function call
+            if delta.dig("function_call", "name")
+              function_name = delta.dig("function_call", "name")
+            end
+
+            if delta.dig("function_call", "arguments")
+              function_args += delta.dig("function_call", "arguments")
+            end
+          elsif delta["content"]
+            # Regular content
+            full_content += delta["content"]
+            yield delta["content"]
+          end
+        end
+
+        params[:stream] = stream_proc
+        @client.chat(parameters: params)
+
+        if function_name
+          {
+            "role" => "assistant",
+            "function_call" => {
+              "name" => function_name,
+              "arguments" => function_args
+            }
+          }
+        else
+          {
+            "role" => "assistant",
+            "content" => full_content
+          }
+        end
+      end
+
+      def format_functions(functions)
+        {
+          functions: functions.map(&:to_schema),
+          function_call: "auto"
+        }
+      end
+
+      def default_model
+        "gpt-4o-mini"
+      end
+
+      def is_function_call?(response)
+        response["function_call"]
+      end
+
+      def function_name(response)
+        response["function_call"]["name"]
+      end
+
+      def function_arguments(response)
+        JSON.parse(response["function_call"]["arguments"])
+      end
+
+      def format_function_response(response, result)
+        message_hash = {
+          "role" => "function",
+          "name" => response["function_call"]["name"],
+          "content" => result.to_json
+        }
+      end
+    end
+  end
+end

--- a/spec/bristow/configuration_spec.rb
+++ b/spec/bristow/configuration_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Configuration do
+  let(:config) { described_class.new }
+
+  describe "#initialize" do
+    it "sets default values" do
+      expect(config.default_provider).to eq(:openai)
+      expect(config.default_model).to be_nil
+      expect(config.clients).to eq({})
+      expect(config.logger).to be_a(Logger)
+    end
+
+    it "reads API keys from environment" do
+      allow(ENV).to receive(:[]).with('OPENAI_API_KEY').and_return('env-openai-key')
+      allow(ENV).to receive(:[]).with('ANTHROPIC_API_KEY').and_return('env-anthropic-key')
+      allow(ENV).to receive(:[]).with('GOOGLE_API_KEY').and_return('env-google-key')
+
+      config = described_class.new
+
+      expect(config.openai_api_key).to eq('env-openai-key')
+      expect(config.anthropic_api_key).to eq('env-anthropic-key')
+      expect(config.google_api_key).to eq('env-google-key')
+    end
+  end
+
+  describe "API key setters" do
+    it "resets client when OpenAI API key changes" do
+      config.openai_api_key = "old-key"
+      config.client_for(:openai) # This creates the client
+
+      expect(config.clients[:openai]).to be_a(Bristow::Providers::Openai)
+
+      config.openai_api_key = "new-key"
+
+      expect(config.clients[:openai]).to be_nil
+    end
+
+    it "resets client when Anthropic API key changes" do
+      config.anthropic_api_key = "old-key"
+      config.client_for(:anthropic) # This creates the client
+
+      expect(config.clients[:anthropic]).to be_a(Bristow::Providers::Anthropic)
+
+      config.anthropic_api_key = "new-key"
+
+      expect(config.clients[:anthropic]).to be_nil
+    end
+
+    it "resets client when Google API key changes" do
+      config.google_api_key = "old-key"
+      config.client_for(:google) # This creates the client
+
+      expect(config.clients[:google]).to be_a(Bristow::Providers::Google)
+
+      config.google_api_key = "new-key"
+
+      expect(config.clients[:google]).to be_nil
+    end
+  end
+
+  describe "#client_for" do
+    before do
+      config.openai_api_key = "test-openai-key"
+      config.anthropic_api_key = "test-anthropic-key"
+      config.google_api_key = "test-google-key"
+    end
+
+    it "creates and caches OpenAI provider" do
+      client = config.client_for(:openai)
+
+      expect(client).to be_a(Bristow::Providers::Openai)
+      expect(config.client_for(:openai)).to be(client) # Same instance
+    end
+
+    it "creates and caches Anthropic provider" do
+      client = config.client_for(:anthropic)
+
+      expect(client).to be_a(Bristow::Providers::Anthropic)
+      expect(config.client_for(:anthropic)).to be(client) # Same instance
+    end
+
+    it "creates and caches Google provider" do
+      client = config.client_for(:google)
+
+      expect(client).to be_a(Bristow::Providers::Google)
+      expect(config.client_for(:google)).to be(client) # Same instance
+    end
+
+    it "raises error for unknown provider" do
+      expect { config.client_for(:unknown) }.to raise_error(ArgumentError, "Unknown provider: unknown")
+    end
+
+    it "raises error when API key not configured" do
+      config.openai_api_key = nil
+
+      expect { config.client_for(:openai) }.to raise_error(ArgumentError, "OpenAI API key not configured")
+    end
+  end
+
+  describe "#client (backward compatibility)" do
+    before do
+      config.openai_api_key = "test-key"
+      config.default_provider = :openai
+    end
+
+    it "returns client for default provider" do
+      client = config.client
+
+      expect(client).to be_a(Bristow::Providers::Openai)
+      expect(client).to eq(config.client_for(:openai))
+    end
+  end
+
+  describe "#model (backward compatibility)" do
+    before do
+      config.openai_api_key = "test-key"
+      config.default_provider = :openai
+    end
+
+    it "returns default_model when set" do
+      config.default_model = "custom-model"
+
+      expect(config.model).to eq("custom-model")
+    end
+
+    it "returns provider's default model when default_model is nil" do
+      config.default_model = nil
+
+      expect(config.model).to eq("gpt-4o-mini") # OpenAI provider's default
+    end
+  end
+
+  describe "#model=" do
+    it "sets the default_model" do
+      config.model = "custom-model"
+
+      expect(config.default_model).to eq("custom-model")
+    end
+  end
+end

--- a/spec/bristow/function_spec.rb
+++ b/spec/bristow/function_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Bristow::Function do
     end
   end
 
-  describe "#to_openai_schema" do
+  describe "#to_schema" do
     it "returns the correct schema format" do
-      schema = function.to_openai_schema
+      schema = function.to_schema
       expect(schema).to eq({
         name: "test_function",
         description: "A test function",

--- a/spec/bristow/multi_provider_agent_spec.rb
+++ b/spec/bristow/multi_provider_agent_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+RSpec.describe "Multi-Provider Agent Support" do
+  before do
+    # Reset configuration for each test
+    Bristow.reset_configuration!
+    
+    Bristow.configure do |config|
+      config.openai_api_key = "test-openai-key"
+      config.anthropic_api_key = "test-anthropic-key"
+      config.google_api_key = "test-google-key"
+      config.default_provider = :openai
+      config.logger = Logger.new(File::NULL)
+    end
+  end
+
+  describe "Agent provider configuration" do
+    let(:openai_agent_class) do
+      Class.new(Bristow::Agent) do
+        agent_name "OpenAI Agent"
+        provider :openai
+        model "gpt-4o"
+        system_message "You are an OpenAI agent"
+      end
+    end
+
+    let(:anthropic_agent_class) do
+      Class.new(Bristow::Agent) do
+        agent_name "Anthropic Agent"
+        provider :anthropic
+        model "claude-3-opus-20240229"
+        system_message "You are an Anthropic agent"
+      end
+    end
+
+    let(:google_agent_class) do
+      Class.new(Bristow::Agent) do
+        agent_name "Google Agent"
+        provider :google
+        model "gemini-pro"
+        system_message "You are a Google agent"
+      end
+    end
+
+    let(:default_agent_class) do
+      Class.new(Bristow::Agent) do
+        agent_name "Default Agent"
+        system_message "You are a default agent"
+      end
+    end
+
+    describe "class-level provider configuration" do
+      it "configures OpenAI provider" do
+        expect(openai_agent_class.provider).to eq(:openai)
+        expect(openai_agent_class.model).to eq("gpt-4o")
+      end
+
+      it "configures Anthropic provider" do
+        expect(anthropic_agent_class.provider).to eq(:anthropic)
+        expect(anthropic_agent_class.model).to eq("claude-3-opus-20240229")
+      end
+
+      it "configures Google provider" do
+        expect(google_agent_class.provider).to eq(:google)
+        expect(google_agent_class.model).to eq("gemini-pro")
+      end
+
+      it "defaults to configuration default provider" do
+        expect(default_agent_class.provider).to eq(:openai)
+      end
+    end
+
+    describe "instance-level provider configuration" do
+      it "creates OpenAI agent instance" do
+        agent = openai_agent_class.new
+
+        expect(agent.provider).to eq(:openai)
+        expect(agent.model).to eq("gpt-4o")
+        expect(agent.client).to be_a(Bristow::Providers::Openai)
+      end
+
+      it "creates Anthropic agent instance" do
+        agent = anthropic_agent_class.new
+
+        expect(agent.provider).to eq(:anthropic)
+        expect(agent.model).to eq("claude-3-opus-20240229")
+        expect(agent.client).to be_a(Bristow::Providers::Anthropic)
+      end
+
+      it "creates Google agent instance" do
+        agent = google_agent_class.new
+
+        expect(agent.provider).to eq(:google)
+        expect(agent.model).to eq("gemini-pro")
+        expect(agent.client).to be_a(Bristow::Providers::Google)
+      end
+
+      it "creates default agent instance" do
+        agent = default_agent_class.new
+
+        expect(agent.provider).to eq(:openai)
+        expect(agent.client).to be_a(Bristow::Providers::Openai)
+      end
+    end
+
+    describe "dynamic provider override" do
+      it "overrides provider at instantiation" do
+        agent = openai_agent_class.new(provider: :anthropic, model: "claude-3-haiku-20240307")
+
+        expect(agent.provider).to eq(:anthropic)
+        expect(agent.model).to eq("claude-3-haiku-20240307")
+        expect(agent.client).to be_a(Bristow::Providers::Anthropic)
+      end
+
+      it "overrides only provider, keeping class model" do
+        agent = openai_agent_class.new(provider: :google)
+
+        expect(agent.provider).to eq(:google)
+        expect(agent.model).to eq("gpt-4o") # Keeps class-defined model
+        expect(agent.client).to be_a(Bristow::Providers::Google)
+      end
+
+      it "can override to use custom client" do
+        custom_client = double("custom_client")
+        agent = openai_agent_class.new(client: custom_client)
+
+        expect(agent.client).to be(custom_client)
+      end
+    end
+  end
+
+  describe "formatted_functions method" do
+    let(:test_function) do
+      Class.new(Bristow::Function) do
+        function_name "test_function"
+        description "A test function"
+        parameters({
+          type: "object",
+          properties: {
+            param: {
+              type: "string",
+              description: "A test parameter"
+            }
+          },
+          required: ["param"]
+        })
+
+        def perform(param:)
+          { result: param }
+        end
+      end
+    end
+
+    let(:agent_with_functions) do
+      func = test_function
+      Class.new(Bristow::Agent) do
+        agent_name "Function Agent"
+        provider :openai
+        functions [func]
+      end.new
+    end
+
+    it "formats functions using provider's format_functions method" do
+      mock_client = instance_double(Bristow::Providers::Openai)
+      allow(mock_client).to receive(:format_functions)
+        .with([test_function])
+        .and_return({ functions: ["formatted"], function_call: "auto" })
+
+      agent_with_functions.instance_variable_set(:@client, mock_client)
+
+      result = agent_with_functions.formatted_functions
+
+      expect(result).to eq({ functions: ["formatted"], function_call: "auto" })
+    end
+  end
+
+  describe "chat method with different providers" do
+    let(:messages) { [{ "role" => "user", "content" => "Hello" }] }
+
+    describe "OpenAI provider" do
+      let(:agent) do
+        Class.new(Bristow::Agent) do
+          agent_name "OpenAI Test Agent"
+          provider :openai
+          model "gpt-4o-mini"
+        end.new
+      end
+
+      it "calls OpenAI provider's chat method" do
+        mock_client = instance_double(Bristow::Providers::Openai)
+        allow(mock_client).to receive(:format_functions).and_return({})
+        allow(mock_client).to receive(:chat)
+          .with(hash_including(model: "gpt-4o-mini"))
+          .and_return({ "role" => "assistant", "content" => "Hello from OpenAI!" })
+        allow(mock_client).to receive(:is_function_call?).and_return(false)
+
+        agent.instance_variable_set(:@client, mock_client)
+
+        response = agent.chat("Hello")
+
+        expect(response).to include(
+          a_hash_including(
+            "role" => "assistant",
+            "content" => "Hello from OpenAI!"
+          )
+        )
+      end
+
+      it "calls OpenAI provider's stream_chat method when block given" do
+        mock_client = instance_double(Bristow::Providers::Openai)
+        allow(mock_client).to receive(:format_functions).and_return({})
+        allow(mock_client).to receive(:stream_chat) do |params, &block|
+          block.call("Hello ") if block
+          block.call("from ") if block
+          block.call("OpenAI!") if block
+          { "role" => "assistant", "content" => "Hello from OpenAI!" }
+        end
+        allow(mock_client).to receive(:is_function_call?).and_return(false)
+
+        agent.instance_variable_set(:@client, mock_client)
+
+        streamed_content = []
+        response = agent.chat("Hello") { |chunk| streamed_content << chunk }
+
+        expect(streamed_content).to eq(["Hello ", "from ", "OpenAI!"])
+        expect(response).to include(
+          a_hash_including(
+            "role" => "assistant",
+            "content" => "Hello from OpenAI!"
+          )
+        )
+      end
+    end
+
+    describe "Anthropic provider" do
+      let(:agent) do
+        Class.new(Bristow::Agent) do
+          agent_name "Anthropic Test Agent"
+          provider :anthropic
+          model "claude-3-sonnet-20240229"
+        end.new
+      end
+
+      it "calls Anthropic provider's methods" do
+        mock_client = instance_double(Bristow::Providers::Anthropic)
+        allow(mock_client).to receive(:format_functions).and_return({})
+        allow(mock_client).to receive(:chat)
+          .and_raise(NotImplementedError, "Anthropic provider not yet implemented")
+
+        agent.instance_variable_set(:@client, mock_client)
+
+        expect { agent.chat("Hello") }.to raise_error(NotImplementedError, "Anthropic provider not yet implemented")
+      end
+    end
+  end
+
+  describe "backward compatibility" do
+    it "maintains existing OpenAI functionality" do
+      # Create agent without specifying provider (should default to OpenAI)
+      agent_class = Class.new(Bristow::Agent) do
+        agent_name "Legacy Agent"
+        model "gpt-3.5-turbo"
+        system_message "Legacy agent"
+      end
+
+      agent = agent_class.new
+
+      expect(agent.provider).to eq(:openai)
+      expect(agent.model).to eq("gpt-3.5-turbo")
+      expect(agent.client).to be_a(Bristow::Providers::Openai)
+    end
+
+    it "works with existing configuration methods" do
+      # This should work as before
+      expect(Bristow.configuration.client).to be_a(Bristow::Providers::Openai)
+      expect(Bristow.configuration.model).to eq("gpt-4o-mini") # OpenAI default
+    end
+  end
+
+  describe "configuration changes affect new agents" do
+    it "new agents use updated default provider" do
+      agent_class = Class.new(Bristow::Agent) do
+        agent_name "Dynamic Agent"
+      end
+
+      # Change default provider
+      Bristow.configure do |config|
+        config.default_provider = :anthropic
+      end
+
+      agent = agent_class.new
+
+      expect(agent.provider).to eq(:anthropic)
+      expect(agent.client).to be_a(Bristow::Providers::Anthropic)
+    end
+  end
+end

--- a/spec/bristow/providers/anthropic_spec.rb
+++ b/spec/bristow/providers/anthropic_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Providers::Anthropic do
+  let(:provider) { described_class.new(api_key: "test-anthropic-key") }
+
+  describe "#initialize" do
+    it "creates an Anthropic client" do
+      expect(provider.instance_variable_get(:@client)).to be_a(Anthropic::Client)
+    end
+  end
+
+  describe "#default_model" do
+    it "returns claude-3-5-sonnet-20241022" do
+      expect(provider.default_model).to eq("claude-3-5-sonnet-20241022")
+    end
+  end
+
+  describe "#format_functions" do
+    let(:function_double) do
+      double("function", to_schema: { name: "test_function", description: "Test" })
+    end
+
+    it "formats functions for Anthropic" do
+      result = provider.format_functions([function_double])
+      
+      expect(result).to eq({
+        tools: [{
+          "name" => "test_function",
+          "description" => "Test",
+          "input_schema" => nil
+        }]
+      })
+    end
+  end
+
+  describe "#chat" do
+    it "calls Anthropic client and returns message" do
+      mock_response = double("response")
+      content_item = double("content", type: "text", text: "Hello!")
+      allow(mock_response).to receive(:content).and_return([content_item])
+
+      mock_client = instance_double(Anthropic::Client)
+      mock_messages = instance_double("messages")
+      allow(mock_client).to receive(:messages).and_return(mock_messages)
+      allow(mock_messages).to receive(:create).with({
+        model: "claude-3-5-sonnet-20241022",
+        max_tokens: 1024,
+        messages: []
+      }).and_return(mock_response)
+      
+      provider.instance_variable_set(:@client, mock_client)
+      
+      result = provider.chat({ messages: [] })
+      
+      expect(result).to eq({
+        "role" => "assistant",
+        "content" => "Hello!"
+      })
+    end
+  end
+end

--- a/spec/bristow/providers/base_spec.rb
+++ b/spec/bristow/providers/base_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Providers::Base do
+  describe "#initialize" do
+    it "requires an api_key" do
+      expect { described_class.new(api_key: "test-key") }.not_to raise_error
+    end
+
+    it "raises error when api_key is nil" do
+      expect { described_class.new(api_key: nil) }.to raise_error(ArgumentError, "API key is required")
+    end
+
+    it "raises error when api_key is empty" do
+      expect { described_class.new(api_key: "") }.to raise_error(ArgumentError, "API key is required")
+    end
+  end
+
+  describe "abstract methods" do
+    let(:provider) { described_class.new(api_key: "test-key") }
+
+    it "raises NotImplementedError for #chat" do
+      expect { provider.chat({}) }.to raise_error(NotImplementedError, "Subclasses must implement #chat")
+    end
+
+    it "raises NotImplementedError for #stream_chat" do
+      expect { provider.stream_chat({}) }.to raise_error(NotImplementedError, "Subclasses must implement #stream_chat")
+    end
+
+    it "raises NotImplementedError for #format_functions" do
+      expect { provider.format_functions([]) }.to raise_error(NotImplementedError, "Subclasses must implement #format_functions")
+    end
+
+    it "raises NotImplementedError for #default_model" do
+      expect { provider.default_model }.to raise_error(NotImplementedError, "Subclasses must implement #default_model")
+    end
+  end
+end

--- a/spec/bristow/providers/google_spec.rb
+++ b/spec/bristow/providers/google_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Providers::Google do
+  let(:provider) { described_class.new(api_key: "test-google-key") }
+
+  describe "#default_model" do
+    it "returns gemini-pro" do
+      expect(provider.default_model).to eq("gemini-pro")
+    end
+  end
+
+  describe "methods not yet implemented" do
+    it "raises NotImplementedError for #chat" do
+      expect { provider.chat({}) }.to raise_error(NotImplementedError, "Google provider not yet implemented")
+    end
+
+    it "raises NotImplementedError for #stream_chat" do
+      expect { provider.stream_chat({}) }.to raise_error(NotImplementedError, "Google provider not yet implemented")
+    end
+
+    it "raises NotImplementedError for #format_functions" do
+      expect { provider.format_functions([]) }.to raise_error(NotImplementedError, "Google provider not yet implemented")
+    end
+  end
+end

--- a/spec/bristow/providers/openai_spec.rb
+++ b/spec/bristow/providers/openai_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+RSpec.describe Bristow::Providers::Openai do
+  let(:provider) { described_class.new(api_key: "test-openai-key") }
+
+  describe "#initialize" do
+    it "creates an OpenAI client" do
+      expect(provider.instance_variable_get(:@client)).to be_a(OpenAI::Client)
+    end
+  end
+
+  describe "#default_model" do
+    it "returns gpt-4o-mini" do
+      expect(provider.default_model).to eq("gpt-4o-mini")
+    end
+  end
+
+  describe "#format_functions" do
+    let(:function_double) do
+      double("function", to_schema: { name: "test_function", description: "Test" })
+    end
+
+    it "formats functions for OpenAI" do
+      result = provider.format_functions([function_double])
+      
+      expect(result).to eq({
+        functions: [{ name: "test_function", description: "Test" }],
+        function_call: "auto"
+      })
+    end
+  end
+
+  describe "#chat" do
+    it "calls OpenAI client and returns message" do
+      mock_response = {
+        "choices" => [
+          {
+            "message" => {
+              "role" => "assistant", 
+              "content" => "Hello!"
+            }
+          }
+        ]
+      }
+
+      mock_client = instance_double(OpenAI::Client)
+      allow(mock_client).to receive(:chat).with(parameters: { model: "gpt-4o-mini", messages: [] })
+                                          .and_return(mock_response)
+      
+      provider.instance_variable_set(:@client, mock_client)
+      
+      result = provider.chat({ model: "gpt-4o-mini", messages: [] })
+      
+      expect(result).to eq({
+        "role" => "assistant",
+        "content" => "Hello!"
+      })
+    end
+  end
+
+  describe "#stream_chat" do
+    it "handles streaming with content" do
+      mock_client = instance_double(OpenAI::Client)
+      
+      # Mock the streaming behavior
+      allow(mock_client).to receive(:chat) do |args|
+        stream_proc = args[:parameters][:stream]
+        
+        # Simulate streaming chunks
+        stream_proc.call({
+          "choices" => [
+            {
+              "delta" => {
+                "role" => "assistant",
+                "content" => "Hello"
+              }
+            }
+          ]
+        })
+        
+        stream_proc.call({
+          "choices" => [
+            {
+              "delta" => {
+                "content" => " world!"
+              }
+            }
+          ]
+        })
+      end
+      
+      provider.instance_variable_set(:@client, mock_client)
+      
+      yielded_content = []
+      result = provider.stream_chat({ model: "gpt-4o-mini", messages: [] }) do |content|
+        yielded_content << content
+      end
+      
+      expect(yielded_content).to eq(["Hello", " world!"])
+      expect(result).to eq({
+        "role" => "assistant",
+        "content" => "Hello world!"
+      })
+    end
+
+    it "handles streaming with function calls" do
+      mock_client = instance_double(OpenAI::Client)
+      
+      allow(mock_client).to receive(:chat) do |args|
+        stream_proc = args[:parameters][:stream]
+        
+        # Simulate function call chunks
+        stream_proc.call({
+          "choices" => [
+            {
+              "delta" => {
+                "role" => "assistant",
+                "function_call" => {
+                  "name" => "test_function"
+                }
+              }
+            }
+          ]
+        })
+        
+        stream_proc.call({
+          "choices" => [
+            {
+              "delta" => {
+                "function_call" => {
+                  "arguments" => '{"param":'
+                }
+              }
+            }
+          ]
+        })
+        
+        stream_proc.call({
+          "choices" => [
+            {
+              "delta" => {
+                "function_call" => {
+                  "arguments" => '"value"}'
+                }
+              }
+            }
+          ]
+        })
+      end
+      
+      provider.instance_variable_set(:@client, mock_client)
+      
+      result = provider.stream_chat({ model: "gpt-4o-mini", messages: [] })
+      
+      expect(result).to eq({
+        "role" => "assistant",
+        "function_call" => {
+          "name" => "test_function",
+          "arguments" => '{"param":"value"}'
+        }
+      })
+    end
+  end
+end


### PR DESCRIPTION
Add support for Anthropic APIs via a "provider" pattern. This abstracts
away the APIs of various LLM providers in a way that will allow Bristow
to be backed by either Anthropic or OpenAI.

A placeholder is also in place for Google, but not yet implemented.
